### PR TITLE
Pass python test_bulk_update_of_ttls_without_sending_data tests

### DIFF
--- a/api/context_test.go
+++ b/api/context_test.go
@@ -597,7 +597,7 @@ func TestContextCollectionPOST(t *testing.T) {
 	resp := sendrequest(req, context)
 	assert.Equal(http.StatusOK, resp.Code)
 
-	var results syncstorage.PostResults
+	var results PostResults
 	jsbody := resp.Body.Bytes()
 	err := json.Unmarshal(jsbody, &results)
 	if !assert.NoError(err) {
@@ -660,7 +660,7 @@ func TestContextCollectionPOSTNewLines(t *testing.T) {
 		return
 	}
 
-	var results syncstorage.PostResults
+	var results PostResults
 	jsbody := resp.Body.Bytes()
 	err := json.Unmarshal(jsbody, &results)
 	if !assert.NoError(err) {

--- a/api/hawk_test.go
+++ b/api/hawk_test.go
@@ -131,7 +131,7 @@ func TestHawkAuthPOST(t *testing.T) {
 		return
 	}
 
-	var results syncstorage.PostResults
+	var results PostResults
 	jsbody := resp.Body.Bytes()
 	err := json.Unmarshal(jsbody, &results)
 	if !assert.NoError(err) {


### PR DESCRIPTION
- refactor syncstorage.DB.putBSO|updateBSO
  - modified timestamp is not update if only TTL is changed
- fix HTTP API so it converts TTL from user from seconds into
  milliseconds
- updated all tests to match refactoring
