### PR TITLE
pass test_get_collection_ttl

### DIFF
--- a/syncstorage/utils.go
+++ b/syncstorage/utils.go
@@ -68,7 +68,7 @@ func SortIndexOk(sortIndex int) bool {
 }
 
 func TTLOk(ttl int) bool {
-	return (ttl > 0)
+	return (ttl >= 0)
 }
 
 func LimitOk(limit int) bool {


### PR DESCRIPTION
A TTL of 0 is apparently OK, which means expire immediatly. Go figure.
