### PR TITLE
Pass test_handling_of_invalid_bso_fields

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"encoding/json"
@@ -36,7 +37,6 @@ var (
 
 const (
 	MAX_BSO_PER_POST_REQUEST = 100
-	MAX_BSO_PAYLOAD_SIZE     = 256 * 1024
 
 	// maximum number of BSOs per GET request
 	MAX_BSO_GET_LIMIT = 2500
@@ -567,6 +567,65 @@ type PostResults struct {
 	Failed   map[string][]string `json:"failed"`
 }
 
+type parseError struct {
+	bId   string
+	field string
+	msg   string
+}
+
+func (e parseError) Error() string {
+	return fmt.Sprintf("Could not parse field %s: %s", e.field, e.msg)
+}
+
+func parseIntoBSO(jsonData json.RawMessage, bso *syncstorage.PutBSOInput) *parseError {
+	err := json.Unmarshal(jsonData, bso)
+
+	if err == nil {
+		if bso.Id == "" {
+			return &parseError{field: "id", msg: "Could not parse id"}
+		}
+		return nil
+	}
+
+	// try to isolate the json error to the field
+	var (
+		bid struct {
+			Id string `json:"id"`
+		}
+		payload struct {
+			Payload string `json:"payload"`
+		}
+		ttl struct {
+			TTL int `json:"ttl"`
+		}
+		sort struct {
+			SortIndex int `json:"sortindex"`
+		}
+	)
+
+	// figure out what went wrong and return a parseError
+	if err := json.Unmarshal(jsonData, &bid); err != nil {
+		return &parseError{field: "id", msg: err.Error()}
+	} else if bid.Id == "" {
+		return &parseError{field: "id", msg: "Missing id field"}
+	}
+
+	if err := json.Unmarshal(jsonData, &payload); err != nil {
+		return &parseError{bId: bid.Id, field: "payload", msg: err.Error()}
+	}
+
+	if err := json.Unmarshal(jsonData, &ttl); err != nil {
+		return &parseError{bId: bid.Id, field: "ttl", msg: err.Error()}
+	}
+
+	if err := json.Unmarshal(jsonData, &sort); err != nil {
+		return &parseError{bId: bid.Id, field: "sortindex", msg: err.Error()}
+	}
+
+	// this should never happen..
+	return &parseError{msg: "Unknown JSON parse error"}
+}
+
 func (c *Context) hCollectionPOST(w http.ResponseWriter, r *http.Request, uid string) {
 	// accept text/plain from old (broken) clients
 	ct := r.Header.Get("Content-Type")
@@ -576,64 +635,48 @@ func (c *Context) hCollectionPOST(w http.ResponseWriter, r *http.Request, uid st
 		return
 	}
 
-	// parsing the results is sort of ugly since fields can be left out
-	// if they are not to be submitted
-	var posted syncstorage.PostBSOInput
+	// a list of all the raw json encoded BSOs
+	var raw []json.RawMessage
 
 	if ct == "application/json" || ct == "text/plain" {
 		decoder := json.NewDecoder(r.Body)
-		err := decoder.Decode(&posted)
+		err := decoder.Decode(&raw)
 		if err != nil {
 			http.Error(w, "Invalid JSON posted", http.StatusBadRequest)
 			return
 		}
-	} else { // decode application/newlines
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "Could not read Body", http.StatusInternalServerError)
-			return
+	} else { // deal with application/newlines
+		raw = []json.RawMessage{}
+		scanner := bufio.NewScanner(r.Body)
+		for scanner.Scan() {
+			bsoBytes := scanner.Bytes()
+			raw = append(raw, bsoBytes)
 		}
+	}
 
-		splitData := bytes.Split(body, []byte("\n"))
-		posted = syncstorage.PostBSOInput{}
-		for i, data := range splitData {
-			var bso syncstorage.PutBSOInput
+	// bsoToBeProcessed will actually get sent to the DB
+	bsoToBeProcessed := syncstorage.PostBSOInput{}
+	results := syncstorage.NewPostResults(syncstorage.Now())
 
-			// skip empty lines
-			if strings.TrimSpace(string(data)) == "" {
+	for _, rawJSON := range raw {
+		var b syncstorage.PutBSOInput
+		if err := parseIntoBSO(rawJSON, &b); err == nil {
+			bsoToBeProcessed = append(bsoToBeProcessed, &b)
+		} else {
+			// error in the id field, just skip it...nothing
+			// can be done about it
+			if err.field == "id" {
 				continue
 			}
 
-			if err := json.Unmarshal(data, &bso); err == nil {
-				posted = append(posted, &bso)
-			} else {
-				http.Error(w,
-					fmt.Sprintf("Invalid JSON posted for item: %d, %v, %s",
-						i, err, string(data)),
-					http.StatusBadRequest)
-				return
-			}
+			results.AddFailure(err.bId, fmt.Sprintf("invalid %s", err.field))
 		}
 	}
 
-	if len(posted) > MAX_BSO_PER_POST_REQUEST {
+	if len(bsoToBeProcessed) > MAX_BSO_PER_POST_REQUEST {
 		http.Error(w, fmt.Sprintf("Exceeded %d BSO per request", MAX_BSO_PER_POST_REQUEST),
 			http.StatusRequestEntityTooLarge)
 		return
-	}
-
-	// validate basic bso data
-	for _, b := range posted {
-		if !syncstorage.BSOIdOk(b.Id) {
-			http.Error(w, "Invalid or missing Id in data", http.StatusBadRequest)
-			return
-		}
-
-		if b.Payload != nil && len(*b.Payload) > MAX_BSO_PAYLOAD_SIZE {
-			http.Error(w, fmt.Sprintf("%s payload greater than max of %d bytes",
-				b.Id, MAX_BSO_PAYLOAD_SIZE), http.StatusBadRequest)
-			return
-		}
 	}
 
 	cId, err := c.getcid(r, uid, true) // automake the collection if it doesn't exit
@@ -648,22 +691,27 @@ func (c *Context) hCollectionPOST(w http.ResponseWriter, r *http.Request, uid st
 
 	// change posted[].TTL from seconds (what clients send)
 	// to milliseconds (what the DB uses)
-	for _, p := range posted {
+	for _, p := range bsoToBeProcessed {
 		if p.TTL != nil {
 			tmp := *p.TTL * 1000
 			p.TTL = &tmp
 		}
 	}
 
-	results, err := c.Dispatch.PostBSOs(uid, cId, posted)
+	postResults, err := c.Dispatch.PostBSOs(uid, cId, bsoToBeProcessed)
 	if err != nil {
 		c.Error(w, r, err)
 	} else {
 		m := syncstorage.ModifiedToString(results.Modified)
+
+		for bsoId, failMessage := range postResults.Failed {
+			results.Failed[bsoId] = failMessage
+		}
+
 		w.Header().Set("X-Last-Modified", m)
 		c.JsonNewline(w, r, &PostResults{
 			Modified: m,
-			Success:  results.Success,
+			Success:  postResults.Success,
 			Failed:   results.Failed,
 		})
 	}
@@ -704,7 +752,7 @@ func (c *Context) hCollectionDELETE(w http.ResponseWriter, r *http.Request, uid 
 func (c *Context) getbso(w http.ResponseWriter, r *http.Request) (bId string, ok bool) {
 	bId, ok = mux.Vars(r)["bsoId"]
 	if !ok || !syncstorage.BSOIdOk(bId) {
-		http.Error(w, "Invalid bso ID", http.StatusBadRequest)
+		http.Error(w, "Invalid bso ID", http.StatusNotFound)
 	}
 
 	return
@@ -774,7 +822,7 @@ func (c *Context) hBsoGET(w http.ResponseWriter, r *http.Request, uid string) {
 			return
 		}
 
-		apiDebug("hBsoGet X-If-Unmodified-Since: %s, converted: %d, modified: %d", unmodSince, ts, modified)
+		//apiDebug("hBsoGet X-If-Unmodified-Since: %s, converted: %d, modified: %d", unmodSince, ts, modified)
 
 		if modified >= ts {
 			w.Header().Set("Content-Type", "text/plain; charset=utf8")
@@ -812,7 +860,8 @@ func (c *Context) hBsoPUT(w http.ResponseWriter, r *http.Request, uid string) {
 	}
 
 	cId, err = c.getcid(r, uid, true)
-	if err == syncstorage.ErrNotFound {
+	if err != nil {
+		c.Error(w, r, err)
 		return
 	}
 

--- a/api/context.go
+++ b/api/context.go
@@ -40,6 +40,15 @@ const (
 
 	// maximum number of BSOs per GET request
 	MAX_BSO_GET_LIMIT = 2500
+
+	// old legacy stuff, used to keep compatibility with python/old clients
+	// https://github.com/mozilla-services/server-syncstorage/blob/fd3c8b90278cb9944cb224964af6e6dae19c9263/syncstorage/tweens.py#L17-L21
+
+	WEAVE_UNKNOWN_ERROR  = "0"
+	WEAVE_ILLEGAL_METH   = "1"  // Illegal method/protocol
+	WEAVE_MALFORMED_JSON = "6"  // Json parse failure
+	WEAVE_INVALID_WBO    = "8"  // Invalid Weave Basic Object
+	WEAVE_OVER_QUOTA     = "14" // User over quota
 )
 
 // NewRouterFromContext creates a mux.Router and registers handlers from
@@ -888,7 +897,7 @@ func (c *Context) hBsoPUT(w http.ResponseWriter, r *http.Request, uid string) {
 	if err := parseIntoBSO(body, &bso); err != nil && err.field != "id" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("8"))
+		w.Write([]byte(WEAVE_INVALID_WBO))
 		return
 	}
 

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -585,13 +585,13 @@ func TestParseIntoBSO(t *testing.T) {
 
 	{
 		var b syncstorage.PutBSOInput
-		j := []byte(`{"id":"bso1", "payload": "payload", "sortIndex": 1, "ttl": 2100000}`)
+		j := []byte(`{"id":"bso1", "payload": "payload", "sortindex": 1, "ttl": 2100000}`)
 		assert.Nil(parseIntoBSO(j, &b))
 	}
 
 	{
 		var b syncstorage.PutBSOInput
-		j := []byte(`{"payload": "payload", "sortIndex": 1, "ttl": 2100000}`)
+		j := []byte(`{"payload": "payload", "sortindex": 1, "ttl": 2100000}`)
 		e := parseIntoBSO(j, &b)
 		if assert.NotNil(e) {
 			assert.Equal("", e.bId)
@@ -601,7 +601,7 @@ func TestParseIntoBSO(t *testing.T) {
 
 	{
 		var b syncstorage.PutBSOInput
-		j := []byte(`{"id":"bso1", "payload": 1234, "sortIndex": 1, "ttl": 2100000}`)
+		j := []byte(`{"id":"bso1", "payload": 1234, "sortindex": 1, "ttl": 2100000}`)
 		e := parseIntoBSO(j, &b)
 		if assert.NotNil(e) {
 			assert.Equal("payload", e.field)
@@ -610,7 +610,7 @@ func TestParseIntoBSO(t *testing.T) {
 
 	{
 		var b syncstorage.PutBSOInput
-		j := []byte(`{"id":"bso1", "payload": "payload", "sortIndex": "meh", "ttl": 2100000}`)
+		j := []byte(`{"id":"bso1", "payload": "payload", "sortindex": "meh", "ttl": 2100000}`)
 		e := parseIntoBSO(j, &b)
 		if assert.NotNil(e) {
 			assert.Equal("sortindex", e.field)
@@ -619,7 +619,7 @@ func TestParseIntoBSO(t *testing.T) {
 
 	{
 		var b syncstorage.PutBSOInput
-		j := []byte(`{"id":"bso1", "payload": "payload", "sortIndex": "1", "ttl": "eh"}`)
+		j := []byte(`{"id":"bso1", "payload": "payload", "sortindex": "1", "ttl": "eh"}`)
 		e := parseIntoBSO(j, &b)
 		if assert.NotNil(e) {
 			assert.Equal("ttl", e.field)
@@ -636,9 +636,9 @@ func TestContextCollectionPOST(t *testing.T) {
 
 	// Make sure INSERT works first
 	body := bytes.NewBufferString(`[
-		{"Id":"bso1", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-		{"Id":"bso2", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-		{"Id":"bso3", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000}
+		{"id":"bso1", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+		{"id":"bso2", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+		{"id":"bso3", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
 	]`)
 
 	req, _ := http.NewRequest("POST", "/1.5/"+uid+"/storage/bookmarks", body)
@@ -666,9 +666,9 @@ func TestContextCollectionPOST(t *testing.T) {
 
 	// Test that updates work
 	body = bytes.NewBufferString(`[
-		{"Id":"bso1", "SortIndex": 2},
-		{"Id":"bso2", "Payload": "updated payload"},
-		{"Id":"bso3", "Payload": "updated payload", "SortIndex":3}
+		{"id":"bso1", "sortindex": 2},
+		{"id":"bso2", "payload": "updated payload"},
+		{"id":"bso3", "payload": "updated payload", "sortindex":3}
 	]`)
 
 	req2, _ := http.NewRequest("POST", "http://test/1.5/"+uid+"/storage/bookmarks", body)
@@ -699,9 +699,9 @@ func TestContextCollectionPOSTNewLines(t *testing.T) {
 	// Make sure INSERT works first, with lots of random whitespace
 	body := bytes.NewBufferString(`
 
-	{"Id":"bso1", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000}
-{"Id":"bso2", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000}
-   {"Id":"bso3", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000}
+	{"id":"bso1", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
+{"id":"bso2", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
+   {"id":"bso3", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
 
 
 	`)
@@ -732,9 +732,9 @@ func TestContextCollectionPOSTNewLines(t *testing.T) {
 	}
 
 	// Test that updates work
-	body = bytes.NewBufferString(`{"Id":"bso1", "SortIndex": 2}
-{"Id":"bso2", "Payload": "updated payload"}
-{"Id":"bso3", "Payload": "updated payload", "SortIndex":3}
+	body = bytes.NewBufferString(`{"id":"bso1", "sortindex": 2}
+{"id":"bso2", "payload": "updated payload"}
+{"id":"bso3", "payload": "updated payload", "sortindex":3}
 	`)
 
 	req2, _ := http.NewRequest("POST", "http://test/1.5/"+uid+"/storage/bookmarks", body)
@@ -766,9 +766,9 @@ func TestContextCollectionPOSTCreatesCollection(t *testing.T) {
 
 	// Make sure INSERT works first
 	body := bytes.NewBufferString(`[
-		{"Id":"bso1", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-		{"Id":"bso2", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-		{"Id":"bso3", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000}
+		{"id":"bso1", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+		{"id":"bso2", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+		{"id":"bso3", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
 	]`)
 
 	cName := "my_new_collection"
@@ -830,9 +830,10 @@ func TestContextCollectionDELETE(t *testing.T) {
 	// delete entire collection
 	{
 		body := bytes.NewBufferString(`[
-			{"Id":"bso1", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-			{"Id":"bso2", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-			{"Id":"bso3", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000} ]`)
+			{"id":"bso1", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			{"id":"bso2", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			{"id":"bso3", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
+		]`)
 
 		req, _ := http.NewRequest("POST", "http://test/1.5/"+uid+"/storage/my_collection", body)
 		req.Header.Add("Content-Type", "application/json")
@@ -866,9 +867,10 @@ func TestContextCollectionDELETE(t *testing.T) {
 	// delete only specific ids
 	{
 		body := bytes.NewBufferString(`[
-			{"Id":"bso1", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-			{"Id":"bso2", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-			{"Id":"bso3", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000} ]`)
+			{"id":"bso1", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			{"id":"bso2", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			{"id":"bso3", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
+		]`)
 
 		req, _ := http.NewRequest("POST", "http://test/1.5/"+uid+"/storage/my_collection", body)
 		req.Header.Add("Content-Type", "application/json")

--- a/api/hawk_test.go
+++ b/api/hawk_test.go
@@ -120,9 +120,9 @@ func TestHawkAuthPOST(t *testing.T) {
 	tok := testtoken(context, uid)
 
 	body := bytes.NewBufferString(`[
-		{"Id":"bso1", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-		{"Id":"bso2", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000},
-		{"Id":"bso3", "Payload": "initial payload", "SortIndex": 1, "TTL": 2100000}
+		{"id":"bso1", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+		{"id":"bso2", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+		{"id":"bso3", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
 	]`)
 
 	req, _ := hawkrequestbody("POST", syncurl(uid, "storage/bookmarks"), tok, "application/json", body)

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -55,6 +55,9 @@ const (
 
 	// Keep BSO for 1 year
 	DEFAULT_BSO_TTL = 365 * 24 * 60 * 60 * 1000
+
+	// max BSO size
+	MAX_BSO_PAYLOAD_SIZE = 1024 * 256
 )
 
 type CollectionInfo struct {
@@ -653,7 +656,7 @@ func (d *DB) putBSO(tx dbTx,
 		return
 	}
 
-	if payload != nil && len(*payload) >= (256*1024) {
+	if payload != nil && len(*payload) >= (MAX_BSO_PAYLOAD_SIZE) {
 		err = ErrPayloadTooBig
 		return
 	}


### PR DESCRIPTION
This one turned into a pretty significant refactor of a few things. 
- rewrote `hCollectionPOST` function. It's better now, `application/json`, `text/plain` and `application/newlines` content types all share mostly the same code
- `hCollectionPOST` might be a wee bit slower, but easier to reason about and catches more errors
- added `func parseIntoBSO` which has very strict requirements on bso objects
- updated appropriate tests
