### PR TITLE
Python test handling of invalid json in bso uploads

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -610,7 +610,7 @@ func parseIntoBSO(jsonData json.RawMessage, bso *syncstorage.PutBSOInput) *parse
 	// out which field is borked
 	err = json.Unmarshal(jsonData, bso)
 	if err == nil {
-		if bso.Id == "" {
+		if bso.Id == "" { // id is required
 			return &parseError{field: "id", msg: "Could not parse id"}
 		}
 		return nil
@@ -894,7 +894,7 @@ func (c *Context) hBsoPUT(w http.ResponseWriter, r *http.Request, uid string) {
 	}
 
 	var bso syncstorage.PutBSOInput
-	if err := parseIntoBSO(body, &bso); err != nil && err.field != "id" {
+	if err := parseIntoBSO(body, &bso); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(WEAVE_INVALID_WBO))

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -591,6 +591,15 @@ func TestParseIntoBSO(t *testing.T) {
 
 	{
 		var b syncstorage.PutBSOInput
+		j := []byte(`{invalid json}`)
+		e := parseIntoBSO(j, &b)
+		if assert.NotNil(e) {
+			assert.Equal("-", e.field)
+		}
+	}
+
+	{
+		var b syncstorage.PutBSOInput
 		j := []byte(`{"id": 123, "payload": "payload", "sortindex": 1, "ttl": 2100000}`)
 		e := parseIntoBSO(j, &b)
 		if assert.NotNil(e) {
@@ -789,6 +798,34 @@ func TestContextCollectionPOSTCreatesCollection(t *testing.T) {
 		b, err := context.Dispatch.GetBSO(uid, cId, bId)
 		assert.NotNil(b)
 		assert.NoError(err)
+	}
+}
+
+func TestContextCollectionPOSTWeaveInvalidWSOError(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	context := makeTestContext()
+
+	uid := "123456"
+
+	send := func(body string) *httptest.ResponseRecorder {
+		buf := bytes.NewBufferString(body)
+		req, _ := http.NewRequest("POST", "http://test/1.5/"+uid+"/storage/col2", buf)
+		req.Header.Add("Content-Type", "application/json")
+		return sendrequest(req, context)
+	}
+
+	{
+		resp := send(`[
+			{"id":"bso1", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			"BOOM"
+		]`)
+		assert.Equal(WEAVE_INVALID_WBO, resp.Body.String())
+	}
+
+	{
+		resp := send("42")
+		assert.Equal(WEAVE_INVALID_WBO, resp.Body.String())
 	}
 }
 
@@ -1090,7 +1127,33 @@ func TestContextBsoPUT(t *testing.T) {
 		assert.Equal("updated", b.Payload)
 		assert.Equal(2, b.SortIndex)
 	}
+}
 
+func TestContextBsoPUTWeaveInvalidWSOError(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	context := makeTestContext()
+	uid := "123456"
+	collection := "bookmarks"
+	bId := "test"
+
+	{
+		data := `{"id": [1,2,3], "payload":"hello", "sortindex":1}`
+		body := bytes.NewBufferString(data)
+		resp := request("PUT", "http://test/1.5/"+uid+"/storage/"+collection+"/"+bId, body, context)
+		if assert.Equal(http.StatusBadRequest, resp.Code) {
+			assert.Equal(WEAVE_INVALID_WBO, resp.Body.String())
+		}
+	}
+
+	{
+		data := "42"
+		body := bytes.NewBufferString(data)
+		resp := request("PUT", "http://test/1.5/"+uid+"/storage/"+collection+"/"+bId, body, context)
+		if assert.Equal(http.StatusBadRequest, resp.Code) {
+			assert.Equal(WEAVE_INVALID_WBO, resp.Body.String())
+		}
+	}
 }
 
 func TestContextBsoDELETE(t *testing.T) {

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -591,7 +591,7 @@ func TestParseIntoBSO(t *testing.T) {
 
 	{
 		var b syncstorage.PutBSOInput
-		j := []byte(`{"payload": "payload", "sortindex": 1, "ttl": 2100000}`)
+		j := []byte(`{"id": 123, "payload": "payload", "sortindex": 1, "ttl": 2100000}`)
 		e := parseIntoBSO(j, &b)
 		if assert.NotNil(e) {
 			assert.Equal("", e.bId)

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -1018,7 +1018,7 @@ func TestContextBsoPUT(t *testing.T) {
 	{
 		testNum++
 		bsoId := "test" + strconv.Itoa(testNum)
-		data := `{"payload":"hello","sortindex":1, "ttl": 1000000}`
+		data := `{"id":"` + bsoId + `", "payload":"hello","sortindex":1, "ttl": 1000000}`
 		body := bytes.NewBufferString(data)
 		resp := request("PUT", "http://test/1.5/"+uid+"/storage/"+collection+"/"+bsoId, body, context)
 		if !assert.Equal(http.StatusOK, resp.Code) {
@@ -1036,7 +1036,7 @@ func TestContextBsoPUT(t *testing.T) {
 	{ // test with fewer params
 		testNum++
 		bsoId := "test" + strconv.Itoa(testNum)
-		data := `{"payload":"hello","sortindex":1}`
+		data := `{"id":"` + bsoId + `", "payload":"hello","sortindex":1}`
 		body := bytes.NewBufferString(data)
 		resp := request("PUT", "http://test/1.5/"+uid+"/storage/"+collection+"/"+bsoId, body, context)
 		if !assert.Equal(http.StatusOK, resp.Code) {
@@ -1051,7 +1051,7 @@ func TestContextBsoPUT(t *testing.T) {
 	{ // test with fewer params
 		testNum++
 		bsoId := "test" + strconv.Itoa(testNum)
-		data := `{"payload":"hello", "sortindex":1}`
+		data := `{"id":"` + bsoId + `", "payload":"hello", "sortindex":1}`
 		body := bytes.NewBufferString(data)
 		resp := request("PUT", "http://test/1.5/"+uid+"/storage/"+collection+"/"+bsoId, body, context)
 		if !assert.Equal(http.StatusOK, resp.Code) {
@@ -1066,7 +1066,7 @@ func TestContextBsoPUT(t *testing.T) {
 	{ // Test Updates
 		testNum++
 		bsoId := "test" + strconv.Itoa(testNum)
-		data := `{"payload":"hello", "sortindex":1}`
+		data := `{"id":"` + bsoId + `", "payload":"hello", "sortindex":1}`
 		body := bytes.NewBufferString(data)
 		resp := request("PUT", "http://test/1.5/"+uid+"/storage/"+collection+"/"+bsoId, body, context)
 		if !assert.Equal(http.StatusOK, resp.Code) {
@@ -1077,7 +1077,7 @@ func TestContextBsoPUT(t *testing.T) {
 		assert.NotNil(b)
 		assert.NoError(err)
 
-		data = `{"payload":"updated", "sortindex":2}`
+		data = `{"id":"` + bsoId + `", "payload":"updated", "sortindex":2}`
 		body = bytes.NewBufferString(data)
 		resp = request("PUT", "http://test/1.5/"+uid+"/storage/"+collection+"/"+bsoId, body, context)
 		if !assert.Equal(http.StatusOK, resp.Code) {


### PR DESCRIPTION
Chasing down behaviour of PUT/POST :)
- refactor `parseIntoBSO` so `id` is optional, but if there, must parse into a valid string
- add similar tests as in python
- fix behaviour in `PUT /{collection}/{bso}` so it returns the weird weave errors
