### PR TITLE
lPass test_if_modified_since_on_info_views

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -401,6 +401,10 @@ func (c *Context) hInfoCollections(w http.ResponseWriter, r *http.Request, uid s
 			}
 		}
 
+		if sentNotModified(w, r, modified) {
+			return
+		}
+
 		m := syncstorage.ModifiedToString(modified)
 		w.Header().Set("X-Last-Modified", m)
 		c.JsonNewline(w, r, info)

--- a/api/context.go
+++ b/api/context.go
@@ -281,12 +281,6 @@ func (c *Context) WeaveInvalidWBOError(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(WEAVE_INVALID_WBO))
 }
 
-func (c *Context) NotModified(w http.ResponseWriter, r *http.Request, body string) {
-	w.Header().Set("Content-Type", "text/plain; charset=utf8")
-	w.WriteHeader(http.StatusNotModified)
-	fmt.Fprintln(w, body)
-}
-
 // JsonNewline returns data as newline separated or as a single
 // json array
 func (c *Context) JsonNewline(w http.ResponseWriter, r *http.Request, val interface{}) {
@@ -843,19 +837,7 @@ func (c *Context) hBsoGET(w http.ResponseWriter, r *http.Request, uid string) {
 		return
 	}
 
-	ts, mHeaderType, err := extractModifiedTimestamp(r)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	switch {
-	case mHeaderType == X_IF_MODIFIED_SINCE && modified <= ts:
-		c.NotModified(w, r, http.StatusText(http.StatusNotModified))
-		return
-	case mHeaderType == X_IF_UNMODIFIED_SINCE && modified >= ts:
-		w.Header().Set("Content-Type", "text/plain; charset=utf8")
-		w.WriteHeader(http.StatusPreconditionFailed)
+	if sentNotModified(w, r, modified) {
 		return
 	}
 

--- a/api/context.go
+++ b/api/context.go
@@ -130,7 +130,6 @@ type Context struct {
 func (c *Context) acceptOK(h http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		accept := r.Header.Get("Accept")
-		apiDebug("acceptOK: accept=%s", accept)
 
 		// no Accept defaults to JSON
 		if accept == "" {
@@ -746,11 +745,14 @@ func (c *Context) hCollectionPOST(w http.ResponseWriter, r *http.Request, uid st
 		}
 	}
 
+	// Send the changes to the database and merge
+	// with `results` above
 	postResults, err := c.Dispatch.PostBSOs(uid, cId, bsoToBeProcessed)
+
 	if err != nil {
 		c.Error(w, r, err)
 	} else {
-		m := syncstorage.ModifiedToString(results.Modified)
+		m := syncstorage.ModifiedToString(postResults.Modified)
 
 		for bsoId, failMessage := range postResults.Failed {
 			results.Failed[bsoId] = failMessage

--- a/api/context.go
+++ b/api/context.go
@@ -378,21 +378,11 @@ func (c *Context) handleEchoUID(w http.ResponseWriter, r *http.Request, uid stri
 // TODO actually implement quotas in the system.
 func (c *Context) hInfoQuota(w http.ResponseWriter, r *http.Request, uid string) {
 
-	// figure out if we need to send data
-	info, err := c.Dispatch.InfoCollections(uid)
+	modified, err := c.Dispatch.LastModified(uid)
 	if err != nil {
 		c.Error(w, r, err)
-	} else {
-		modified := 0
-		for _, modtime := range info {
-			if modtime > modified {
-				modified = modtime
-			}
-		}
-
-		if sentNotModified(w, r, modified) {
-			return
-		}
+	} else if sentNotModified(w, r, modified) {
+		return
 	}
 
 	pagestats, err := c.Dispatch.Usage(uid)
@@ -429,6 +419,13 @@ func (c *Context) hInfoCollections(w http.ResponseWriter, r *http.Request, uid s
 }
 
 func (c *Context) hInfoCollectionUsage(w http.ResponseWriter, r *http.Request, uid string) {
+	modified, err := c.Dispatch.LastModified(uid)
+	if err != nil {
+		c.Error(w, r, err)
+	} else if sentNotModified(w, r, modified) {
+		return
+	}
+
 	results, err := c.Dispatch.InfoCollectionUsage(uid)
 	if err != nil {
 		c.Error(w, r, err)
@@ -443,6 +440,13 @@ func (c *Context) hInfoCollectionUsage(w http.ResponseWriter, r *http.Request, u
 }
 
 func (c *Context) hInfoCollectionCounts(w http.ResponseWriter, r *http.Request, uid string) {
+	modified, err := c.Dispatch.LastModified(uid)
+	if err != nil {
+		c.Error(w, r, err)
+	} else if sentNotModified(w, r, modified) {
+		return
+	}
+
 	results, err := c.Dispatch.InfoCollectionCounts(uid)
 	if err != nil {
 		c.Error(w, r, err)

--- a/api/context.go
+++ b/api/context.go
@@ -377,6 +377,24 @@ func (c *Context) handleEchoUID(w http.ResponseWriter, r *http.Request, uid stri
 // it based on the number of DB pages used * size of each page.
 // TODO actually implement quotas in the system.
 func (c *Context) hInfoQuota(w http.ResponseWriter, r *http.Request, uid string) {
+
+	// figure out if we need to send data
+	info, err := c.Dispatch.InfoCollections(uid)
+	if err != nil {
+		c.Error(w, r, err)
+	} else {
+		modified := 0
+		for _, modtime := range info {
+			if modtime > modified {
+				modified = modtime
+			}
+		}
+
+		if sentNotModified(w, r, modified) {
+			return
+		}
+	}
+
 	pagestats, err := c.Dispatch.Usage(uid)
 	if err != nil {
 		c.Error(w, r, err)

--- a/api/util.go
+++ b/api/util.go
@@ -45,7 +45,7 @@ func extractModifiedTimestamp(r *http.Request) (ts int, headerType XModHeader, e
 
 	if modSince != "" {
 		ts, err := ConvertTimestamp(modSince)
-		if err != nil {
+		if err != nil || ts < 0 {
 			return 0, X_TS_HEADER_NONE, errors.New("Invalid X-If-Modified-Since")
 		}
 
@@ -54,7 +54,7 @@ func extractModifiedTimestamp(r *http.Request) (ts int, headerType XModHeader, e
 
 	if unmodSince != "" {
 		ts, err := ConvertTimestamp(unmodSince)
-		if err != nil {
+		if err != nil || ts < 0 {
 			return 0, X_TS_HEADER_NONE, errors.New("Invalid X-If-Unmodified-Since")
 		}
 

--- a/api/util.go
+++ b/api/util.go
@@ -1,6 +1,10 @@
 package api
 
-import "strconv"
+import (
+	"errors"
+	"net/http"
+	"strconv"
+)
 
 // ConvertTimestamp converts the sync decimal time in seconds to
 // a time in milliseconds
@@ -13,4 +17,49 @@ func ConvertTimestamp(ts string) (int, error) {
 
 	return int(f * 1000), nil
 
+}
+
+// The code below is a little weird and inelegant. Basically its purpose is
+// to reduce boilerplate in the handlers for dealing with the X-If-Modified-Since and
+// X-If-Unmodified-Since header logic from clients
+
+type XModHeader int
+
+const (
+	X_TS_HEADER_NONE      XModHeader = iota
+	X_IF_MODIFIED_SINCE              // X-If-Modified-Since
+	X_IF_UNMODIFIED_SINCE            // X-If-Unmodified
+)
+
+// extractModified will extract either the X-Modified-Since or the X-If-Unmodified-Since
+// headers from the request
+func extractModifiedTimestamp(r *http.Request) (ts int, headerType XModHeader, err error) {
+
+	modSince := r.Header.Get("X-If-Modified-Since")
+	unmodSince := r.Header.Get("X-If-Unmodified-Since")
+
+	if modSince != "" && unmodSince != "" {
+		return 0, X_TS_HEADER_NONE, errors.New("X-If-Modified-Since and X-If-Unmodified-Since both provided")
+		return
+	}
+
+	if modSince != "" {
+		ts, err := ConvertTimestamp(modSince)
+		if err != nil {
+			return 0, X_TS_HEADER_NONE, errors.New("Invalid X-If-Modified-Since")
+		}
+
+		return ts, X_IF_MODIFIED_SINCE, nil
+	}
+
+	if unmodSince != "" {
+		ts, err := ConvertTimestamp(unmodSince)
+		if err != nil {
+			return 0, X_TS_HEADER_NONE, errors.New("Invalid X-If-Unmodified-Since")
+		}
+
+		return ts, X_IF_UNMODIFIED_SINCE, nil
+	}
+
+	return 0, X_TS_HEADER_NONE, nil
 }

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -196,6 +196,15 @@ func NewDB(path string) (*DB, error) {
   work is handled by private functions.
 */
 
+// LastModified gets the database modified time
+func (d *DB) LastModified() (modified int, err error) {
+	d.Lock()
+	defer d.Unlock()
+
+	err = d.db.QueryRow("SELECT max(modified) FROM Collections").Scan(&modified)
+	return
+}
+
 func (d *DB) GetCollectionId(name string) (id int, err error) {
 	d.Lock()
 	defer d.Unlock()

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -416,28 +416,28 @@ func (d *DB) PostBSOs(cId int, input PostBSOInput) (*PostResults, error) {
 		return nil, err
 	}
 
-	modified := Now()
-	results := NewPostResults(modified)
+	results := NewPostResults(Now())
 
+	// note, notice that modified is updated in the loop
 	for _, data := range input {
-		_, err = d.putBSO(tx, cId, data.Id, data.Payload, data.SortIndex, data.TTL)
+		m, err := d.putBSO(tx, cId, data.Id, data.Payload, data.SortIndex, data.TTL)
 		if err != nil {
 			results.AddFailure(data.Id, err.Error())
 			continue
 		} else {
 			results.AddSuccess(data.Id)
+			results.Modified = m
 		}
 	}
 
 	// update the collection
-	err = d.touchCollection(tx, cId, modified)
+	err = d.touchCollection(tx, cId, results.Modified)
 	if err != nil {
 		tx.Rollback()
 		return nil, err
 	}
 
 	tx.Commit()
-
 	return results, nil
 }
 

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -381,6 +381,13 @@ func TestPrivateGetBSOsSort(t *testing.T) {
 	}
 }
 
+func TestLastModified(t *testing.T) {
+	t.Parallel()
+	db, _ := getTestDB()
+	defer removeTestDB(db)
+	testApiLastModified(db, t)
+}
+
 func TestGetCollectionId(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()

--- a/syncstorage/dispatch.go
+++ b/syncstorage/dispatch.go
@@ -46,6 +46,10 @@ func (d *Dispatch) Index(uid string) uint16 {
 // the file path of the sqlite3 files.
 // =======================================================
 
+func (d *Dispatch) LastModified(uid string) (int, error) {
+	pool := d.pools[d.Index(uid)]
+	return pool.LastModified(uid)
+}
 func (d *Dispatch) GetCollectionId(uid string, name string) (id int, err error) {
 	pool := d.pools[d.Index(uid)]
 	return pool.GetCollectionId(uid, name)

--- a/syncstorage/dispatchwrap.go
+++ b/syncstorage/dispatchwrap.go
@@ -10,6 +10,9 @@ type dispatchwrap struct {
 // =======================================================
 // Implement SyncApi
 // =======================================================
+func (d *dispatchwrap) LastModified() (int, error) {
+	return d.dispatch.LastModified(d.uid)
+}
 
 func (d *dispatchwrap) GetCollectionId(name string) (id int, err error) {
 	return d.dispatch.GetCollectionId(d.uid, name)

--- a/syncstorage/pool.go
+++ b/syncstorage/pool.go
@@ -179,6 +179,14 @@ func (p *Pool) returndb(uid string) {
 // method takes a `uid string`. This `uid` is used for
 // the file path of the sqlite3 files.
 // =======================================================
+func (p *Pool) LastModified(uid string) (modified int, err error) {
+	db, err := p.borrowdb(uid)
+	defer p.returndb(uid)
+	if err != nil {
+		return
+	}
+	return db.LastModified()
+}
 
 func (p *Pool) GetCollectionId(uid string, name string) (id int, err error) {
 	db, err := p.borrowdb(uid)

--- a/syncstorage/poolwrap.go
+++ b/syncstorage/poolwrap.go
@@ -10,7 +10,9 @@ type poolwrap struct {
 // =======================================================
 // Implement SyncApi
 // =======================================================
-
+func (p *poolwrap) LastModified() (int, error) {
+	return p.pool.LastModified(p.uid)
+}
 func (p *poolwrap) GetCollectionId(name string) (id int, err error) {
 	return p.pool.GetCollectionId(p.uid, name)
 }

--- a/syncstorage/syncapi.go
+++ b/syncstorage/syncapi.go
@@ -7,6 +7,7 @@ package syncstorage
 // This was created so we can test syncstorage.Pool and syncstorage.DB
 // using similar code
 type SyncApi interface {
+	LastModified() (int, error)
 	GetCollectionId(name string) (id int, err error)
 	GetCollectionModified(cId int) (modified int, err error)
 

--- a/syncstorage/syncapi_test.go
+++ b/syncstorage/syncapi_test.go
@@ -10,6 +10,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func testApiLastModified(db SyncApi, t *testing.T) {
+	assert := assert.New(t)
+	_, err := db.CreateCollection("col1")
+	if !assert.NoError(err) {
+		return
+	}
+	col2, err := db.CreateCollection("col2")
+	if !assert.NoError(err) {
+		return
+	}
+	_, err = db.CreateCollection("col3")
+	if !assert.NoError(err) {
+		return
+	}
+
+	modified := Now() + 100000
+	if !assert.NoError(db.TouchCollection(col2, modified)) {
+		return
+	}
+
+	m, err := db.LastModified()
+	if !assert.NoError(err) {
+		return
+	}
+
+	assert.Equal(modified, m)
+}
+
 func testApiGetCollectionId(db SyncApi, t *testing.T) {
 	_, err := db.GetCollectionId("bookmarks")
 	assert.NoError(t, err)


### PR DESCRIPTION
This turned out to be quite a bit of work as it required refactoring a few things. Handling the `X-If-Modified-Since` and `X-If-Unmodified-Since` resulted in a lot of boilerplate code. So I spent some time abstracting it out so writing handlers is much more elegant. 

Also had to add a new method, `LastModified()` to `syncstorage.SyncApi` interface to get the global last modified timestamp for a user's database. This info is pulled out of the `Collections` table since the appropriate collection is touched with the BSOs inside it changes. 

Also tracked down a really annoying incorrect timestamp in `X-Last-Modified` in `hCollectionPost` in commit d818781eb132402a075c0b0c9cfbaa7696f5c082
