### PR TITLE
Fix bug SQL bug with DELETE followed by query

### DIFF
--- a/api/context_test.go
+++ b/api/context_test.go
@@ -1327,3 +1327,25 @@ func TestContextDelete(t *testing.T) {
 	}
 
 }
+
+// Some DB functions use sql.Row.Scan() into a real type
+// and that caused sql errors, need to use the NullString, NullX
+// types to make sure the db returned something before actually
+// doing a type conversion
+func TestContextDeleteAndDBScanBug(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	context := makeTestContext()
+	uid := "144819"
+	resp := request("DELETE", "/1.5/"+uid, nil, context)
+	assert.Equal(http.StatusOK, resp.Code)
+
+	_, err := context.Dispatch.LastModified(uid)
+	assert.NoError(err)
+
+	_, err = context.Dispatch.GetCollectionModified(uid, 1)
+	assert.NoError(err)
+
+	_, err = context.Dispatch.GetCollectionId(uid, "bookmarks")
+	assert.Equal(syncstorage.ErrNotFound, err)
+}

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -201,7 +201,17 @@ func (d *DB) LastModified() (modified int, err error) {
 	d.Lock()
 	defer d.Unlock()
 
-	err = d.db.QueryRow("SELECT max(modified) FROM Collections").Scan(&modified)
+	var m sql.NullInt64
+
+	err = d.db.QueryRow("SELECT max(modified) FROM Collections").Scan(&m)
+	if err == nil {
+		if !m.Valid {
+			return 0, nil
+		} else {
+			return int(m.Int64), nil
+		}
+	}
+
 	return
 }
 
@@ -228,6 +238,10 @@ func (d *DB) GetCollectionModified(cId int) (modified int, err error) {
 	d.Lock()
 	defer d.Unlock()
 	err = d.db.QueryRow("SELECT modified FROM Collections where Id=?", cId).Scan(&modified)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+
 	return
 }
 


### PR DESCRIPTION
- should have used golang's sql.NullInt64 instead of trying to
  convert directly to a real type
- found in python test `test_quota`
