### PR TITLE
Fix incorrect X-Weave-Timestamp behaviour

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -371,6 +372,12 @@ func (c *Context) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *Context) handleEchoUID(w http.ResponseWriter, r *http.Request, uid string) {
+
+	// sleep here to make sure X-Weave-Timestamp code puts in
+	// a to spec value
+	time.Sleep(100 * time.Millisecond)
+
+	w.Header().Set("X-Last-Modified", syncstorage.ModifiedToString(syncstorage.Now()))
 	okResponse(w, uid)
 }
 

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -234,9 +234,29 @@ func TestContextHasXWeaveTimestamp(t *testing.T) {
 }
 
 func TestContextEchoUID(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
 	resp := request("GET", "/1.5/123456/echo-uid", nil, nil)
-	assert.Equal(t, http.StatusOK, resp.Code)
-	assert.Equal(t, "123456", resp.Body.String())
+
+	assert.NotEqual("", resp.Header().Get("X-Weave-Timestamp"))
+	assert.NotEqual("", resp.Header().Get("X-Last-Modified"))
+	assert.Equal(http.StatusOK, resp.Code)
+	assert.Equal("123456", resp.Body.String())
+}
+
+// TestContextXWeaveTimestamp makes sure header exists
+// and is set to the correct value
+func TestContextXWeaveTimestamp(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+	resp := request("GET", "/1.5/123456/echo-uid", nil, nil)
+
+	ts := resp.Header().Get("X-Weave-Timestamp")
+	lm := resp.Header().Get("X-Last-Modified")
+
+	assert.NotEqual(ts, "")
+	assert.NotEqual(lm, "")
+	assert.Equal(ts, lm)
 }
 
 func TestContextInfoQuota(t *testing.T) {


### PR DESCRIPTION
- the X-Weave-Timestamp should be written as late as possible
- it should match X-Last-Modified (if it exists)
- it should be the server's time if X-L-M doesn't exist
