### PR TITLE
Refactor api

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"bufio"
-	"bytes"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,8 +16,6 @@ import (
 	"github.com/gorilla/mux"
 	. "github.com/mostlygeek/go-debug"
 	"github.com/mostlygeek/go-syncstorage/syncstorage"
-	"github.com/mostlygeek/go-syncstorage/token"
-	"github.com/mozilla-services/hawk-go"
 )
 
 var apiDebug = Debug("syncapi")
@@ -145,105 +141,6 @@ func (c *Context) acceptOK(h http.HandlerFunc) http.HandlerFunc {
 		} else {
 			h(w, r)
 		}
-	})
-}
-
-// hawk checks HAWK authentication headers and returns an unauthorized response
-// if they are invalid otherwise passes call to syncApiHandler
-func (c *Context) hawk(h syncApiHandler) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
-		// have the ability to disable hawk auth for testing purposes
-		// when hawk is disabled we need to pull the uid from the
-		// url params... when hawk is enabled the uid comes from the Token sent
-		// by the tokenserver
-		if c.DisableHawk {
-			vars := mux.Vars(r)
-			if uid, ok := vars["uid"]; !ok {
-				http.Error(w, "do not have a uid to work with", http.StatusBadRequest)
-			} else {
-				authDebug("Hawk disabled. Using uid: %s", uid)
-				h(w, r, uid)
-			}
-
-			return
-		}
-
-		// Step 1: Ensure the Hawk header is OK. Use ParseRequestHeader
-		// so the token does not have to be parsed twice to extract
-		// the UID from it
-		auth, err := hawk.NewAuthFromRequest(r, nil, nil)
-		if err != nil {
-			if e, ok := err.(hawk.AuthFormatError); ok {
-				http.Error(w,
-					fmt.Sprintf("Malformed hawk header, field: %s, err: %s", e.Field, e.Err),
-					http.StatusBadRequest)
-			} else {
-				w.Header().Set("WWW-Authenticate", "Hawk")
-				http.Error(w, err.Error(), http.StatusUnauthorized)
-			}
-			return
-		}
-
-		// Step 2: Extract the Token
-		var (
-			parsedToken token.Token
-			tokenError  error = ErrTokenInvalid
-		)
-
-		for _, secret := range c.Secrets {
-			parsedToken, tokenError = token.ParseToken([]byte(secret), auth.Credentials.ID)
-			if err != nil { // wrong secret..
-				continue
-			}
-		}
-
-		if tokenError != nil {
-			authDebug("tokenError: %s", tokenError.Error())
-			http.Error(w,
-				fmt.Sprintf("Invalid token: %s", tokenError.Error()),
-				http.StatusBadRequest)
-			return
-		} else {
-			// required to these manually so the auth.Valid()
-			// check has all the information it needs later
-			auth.Credentials.Key = parsedToken.DerivedSecret
-			auth.Credentials.Hash = sha256.New
-		}
-
-		// Step 3: Make sure it's valid...
-		if err := auth.Valid(); err != nil {
-			w.Header().Set("WWW-Authenticate", "Hawk")
-			http.Error(w, err.Error(), http.StatusUnauthorized)
-			return
-		}
-
-		// Step 4: Validate the payload hash if it exists
-		if auth.Hash != nil {
-			if r.Header.Get("Content-Type") == "" {
-				http.Error(w, "Content-Type missing", http.StatusBadRequest)
-				return
-			}
-
-			// read and replace io.Reader
-			content, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				http.Error(w, "Could not read request body", http.StatusInternalServerError)
-				return
-			}
-
-			r.Body = ioutil.NopCloser(bytes.NewReader(content))
-			pHash := auth.PayloadHash(r.Header.Get("Content-Type"))
-			pHash.Sum(content)
-			if !auth.ValidHash(pHash) {
-				w.Header().Set("WWW-Authenticate", "Hawk")
-				http.Error(w, "Hawk error, payload hash invalid", http.StatusUnauthorized)
-				return
-			}
-		}
-
-		// Step 5: *woot*
-		h(w, r, strconv.FormatUint(parsedToken.Payload.Uid, 10))
 	})
 }
 

--- a/api/context_hawk.go
+++ b/api/context_hawk.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/mostlygeek/go-syncstorage/token"
+	"github.com/mozilla-services/hawk-go"
+)
+
+// hawk checks HAWK authentication headers and returns an unauthorized response
+// if they are invalid otherwise passes call to syncApiHandler
+func (c *Context) hawk(h syncApiHandler) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// have the ability to disable hawk auth for testing purposes
+		// when hawk is disabled we need to pull the uid from the
+		// url params... when hawk is enabled the uid comes from the Token sent
+		// by the tokenserver
+		if c.DisableHawk {
+			vars := mux.Vars(r)
+			if uid, ok := vars["uid"]; !ok {
+				http.Error(w, "do not have a uid to work with", http.StatusBadRequest)
+			} else {
+				authDebug("Hawk disabled. Using uid: %s", uid)
+				h(w, r, uid)
+			}
+
+			return
+		}
+
+		// Step 1: Ensure the Hawk header is OK. Use ParseRequestHeader
+		// so the token does not have to be parsed twice to extract
+		// the UID from it
+		auth, err := hawk.NewAuthFromRequest(r, nil, nil)
+		if err != nil {
+			if e, ok := err.(hawk.AuthFormatError); ok {
+				http.Error(w,
+					fmt.Sprintf("Malformed hawk header, field: %s, err: %s", e.Field, e.Err),
+					http.StatusBadRequest)
+			} else {
+				w.Header().Set("WWW-Authenticate", "Hawk")
+				http.Error(w, err.Error(), http.StatusUnauthorized)
+			}
+			return
+		}
+
+		// Step 2: Extract the Token
+		var (
+			parsedToken token.Token
+			tokenError  error = ErrTokenInvalid
+		)
+
+		for _, secret := range c.Secrets {
+			parsedToken, tokenError = token.ParseToken([]byte(secret), auth.Credentials.ID)
+			if err != nil { // wrong secret..
+				continue
+			}
+		}
+
+		if tokenError != nil {
+			authDebug("tokenError: %s", tokenError.Error())
+			http.Error(w,
+				fmt.Sprintf("Invalid token: %s", tokenError.Error()),
+				http.StatusBadRequest)
+			return
+		} else {
+			// required to these manually so the auth.Valid()
+			// check has all the information it needs later
+			auth.Credentials.Key = parsedToken.DerivedSecret
+			auth.Credentials.Hash = sha256.New
+		}
+
+		// Step 3: Make sure it's valid...
+		if err := auth.Valid(); err != nil {
+			w.Header().Set("WWW-Authenticate", "Hawk")
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		// Step 4: Validate the payload hash if it exists
+		if auth.Hash != nil {
+			if r.Header.Get("Content-Type") == "" {
+				http.Error(w, "Content-Type missing", http.StatusBadRequest)
+				return
+			}
+
+			// read and replace io.Reader
+			content, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "Could not read request body", http.StatusInternalServerError)
+				return
+			}
+
+			r.Body = ioutil.NopCloser(bytes.NewReader(content))
+			pHash := auth.PayloadHash(r.Header.Get("Content-Type"))
+			pHash.Sum(content)
+			if !auth.ValidHash(pHash) {
+				w.Header().Set("WWW-Authenticate", "Hawk")
+				http.Error(w, "Hawk error, payload hash invalid", http.StatusUnauthorized)
+				return
+			}
+		}
+
+		// Step 5: *woot*
+		h(w, r, strconv.FormatUint(parsedToken.Payload.Uid, 10))
+	})
+}

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -119,7 +119,6 @@ func sendrequest(req *http.Request, c *Context) *httptest.ResponseRecorder {
 
 func TestContextJSON(t *testing.T) {
 	assert := assert.New(t)
-	c := makeTestContext()
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/", nil)
 	req.Header.Set("Accept", "application/json")
@@ -133,7 +132,7 @@ func TestContextJSON(t *testing.T) {
 
 	err := json.Unmarshal(js, &val)
 	if assert.NoError(err) {
-		c.JSON(w, req, val)
+		JSON(w, req, val)
 		assert.Equal("application/json", w.HeaderMap.Get("Content-Type"))
 		assert.Equal(`[{"A":"one","B":1},{"A":"two","B":2}]`, w.Body.String())
 	}
@@ -142,7 +141,6 @@ func TestContextJSON(t *testing.T) {
 
 func TestContextNewLine(t *testing.T) {
 	assert := assert.New(t)
-	c := makeTestContext()
 
 	// some test data
 	var val []struct {
@@ -160,7 +158,7 @@ func TestContextNewLine(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set("Accept", "application/newlines")
-		c.NewLine(w, req, val[0])
+		NewLine(w, req, val[0])
 		assert.Equal("application/newlines", w.HeaderMap.Get("Content-Type"))
 		expected := `{"A":"one","B":1}` + "\n"
 		assert.Equal(expected, w.Body.String())
@@ -171,7 +169,7 @@ func TestContextNewLine(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set("Accept", "application/newlines")
-		c.NewLine(w, req, val)
+		NewLine(w, req, val)
 		assert.Equal("application/newlines", w.HeaderMap.Get("Content-Type"))
 		expected := `{"A":"one","B":1}
 {"A":"two","B":2}
@@ -183,7 +181,6 @@ func TestContextNewLine(t *testing.T) {
 
 func TestContextJsonNewline(t *testing.T) {
 	assert := assert.New(t)
-	c := makeTestContext()
 
 	// some test data
 	var val []struct {
@@ -201,7 +198,7 @@ func TestContextJsonNewline(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set("Accept", "application/json")
-		c.JsonNewline(w, req, val)
+		JsonNewline(w, req, val)
 		assert.Equal("application/json", w.HeaderMap.Get("Content-Type"))
 		assert.Equal(`[{"A":"one","B":1},{"A":"two","B":2},{"A":"three","B":3}]`, w.Body.String())
 	}
@@ -211,7 +208,7 @@ func TestContextJsonNewline(t *testing.T) {
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/", nil)
 		req.Header.Set("Accept", "application/newlines")
-		c.JsonNewline(w, req, val)
+		JsonNewline(w, req, val)
 		assert.Equal("application/newlines", w.HeaderMap.Get("Content-Type"))
 		expected := `{"A":"one","B":1}
 {"A":"two","B":2}

--- a/api/x-w-timestamphandler.go
+++ b/api/x-w-timestamphandler.go
@@ -22,6 +22,7 @@ type xWeaveTimestampHandler struct {
 // or WriteHeader(). Since it is not possible to add headers after
 // already sending headers or data to the client.
 type timestampWriter struct {
+	http.ResponseWriter
 	// the original
 	w           http.ResponseWriter
 	wroteHeader bool


### PR DESCRIPTION
context.go was getting way too huge. It was time for a quick refactor: 
- move a bunch of response functions out of context.go and into handlers.go
- some response handlers do not need to funcs on `*Context`, made them generic funcs

context.go should be easier to reason about now.
