### PR TITLE
Fix race condition in pool.borrowdb

### DIFF
--- a/syncstorage/pool.go
+++ b/syncstorage/pool.go
@@ -112,11 +112,11 @@ func (p *Pool) borrowdb(uid string) (*DB, error) {
 		p.locks[uid] = &sync.Mutex{}
 		pDebugCacheB("Created a new lock for %s", uid)
 	}
-	p.Unlock()
 
 	pDebugCacheB("Attempt Lock for %s", uid)
 	p.locks[uid].Lock()
 	pDebugCacheB("Locked %s", uid)
+	p.Unlock()
 
 	var db *DB
 	var ok bool


### PR DESCRIPTION
Particulary nasty panic due to a race reading/writing to a pool's
`locks` map in borrowdb. The fix was to lock the pool until after the
lock was acquired for a specific user.
