### PR TITLE
Set Collection name behaviour to match python storage server

### DIFF
--- a/api/context_test.go
+++ b/api/context_test.go
@@ -28,7 +28,7 @@ var (
 		"tabs",
 		"passwords",
 		"crypto",
-		"client",
+		"clients",
 		"keys",
 		"meta",
 	}
@@ -207,7 +207,7 @@ func TestContextInfoCollections(t *testing.T) {
 		"tabs":      modified + 4000,
 		"passwords": modified + 5000,
 		"crypto":    modified + 6000,
-		"client":    modified + 7000,
+		"clients":   modified + 7000,
 		"keys":      modified + 8000,
 		"meta":      modified + 9000,
 	}
@@ -1293,7 +1293,7 @@ func TestContextDeleteAndDBScanBug(t *testing.T) {
 	assert.NoError(err)
 
 	_, err = context.Dispatch.GetCollectionId(uid, "bookmarks")
-	assert.Equal(syncstorage.ErrNotFound, err)
+	assert.NoError(err)
 
 	_, err = context.Dispatch.GetBSOModified(uid, 1, "test")
 	assert.Equal(syncstorage.ErrNotFound, err)

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -219,6 +219,33 @@ func (d *DB) GetCollectionId(name string) (id int, err error) {
 	d.Lock()
 	defer d.Unlock()
 
+	// return common collection id without touching the DB
+	// ew? yes, but it'll compile nice and fast
+	switch name {
+	case "clients":
+		return 1, nil
+	case "crypto":
+		return 2, nil
+	case "forms":
+		return 3, nil
+	case "history":
+		return 4, nil
+	case "keys":
+		return 5, nil
+	case "meta":
+		return 6, nil
+	case "bookmarks":
+		return 7, nil
+	case "prefs":
+		return 8, nil
+	case "tabs":
+		return 9, nil
+	case "passwords":
+		return 10, nil
+	case "addons":
+		return 11, nil
+	}
+
 	if !CollectionNameOk(name) {
 		err = ErrInvalidCollectionName
 		return
@@ -231,7 +258,6 @@ func (d *DB) GetCollectionId(name string) (id int, err error) {
 	}
 
 	return
-
 }
 
 func (d *DB) GetCollectionModified(cId int) (modified int, err error) {

--- a/syncstorage/schemas.go
+++ b/syncstorage/schemas.go
@@ -22,11 +22,26 @@ const SCHEMA_0 = `
 
 	CREATE TABLE Collections (
 	  -- storage an integer to save some space
-	  Id		INTEGER PRIMARY KEY ASC,
+	  Id		INTEGER PRIMARY KEY ASC AUTOINCREMENT,
 	  Name      VARCHAR(32) UNIQUE,
 
 	  Modified  INTEGER NOT NULL DEFAULT 0
 	);
+
+	INSERT INTO Collections (Id, Name) VALUES
+		( 1, "clients"),
+		( 2, "crypto"),
+		( 3, "forms"),
+		( 4, "history"),
+		( 5, "keys"),
+		( 6, "meta"),
+		( 7, "bookmarks"),
+		( 8, "prefs"),
+		( 9, "tabs"),
+		(10, "passwords"),
+		(11, "addons"),
+		-- forces new collections to start at 100
+		(99, "-push-");
 
 	CREATE TABLE KeyValues (
 		Key VARCHAR(32) NOT NULL,
@@ -35,15 +50,4 @@ const SCHEMA_0 = `
 	);
 
 	INSERT INTO KeyValues (Key, Value) VALUES ("SCHEMA_VERSION", 0);
-	INSERT INTO Collections (Name) VALUES
-		("bookmarks"),
-		("history"),
-		("forms"),
-		("prefs"),
-		("tabs"),
-		("passwords"),
-		("crypto"),
-		("client"),
-		("keys"),
-		("meta");
 	`

--- a/syncstorage/syncapi_test.go
+++ b/syncstorage/syncapi_test.go
@@ -519,7 +519,7 @@ func testApiUsageStats(db SyncApi, t *testing.T) {
 			if assert.NoError(err) {
 
 				// numbers pulled from previous tests
-				assert.Equal(12, pageStats.Total)  // total pages in database
+				assert.Equal(13, pageStats.Total)  // total pages in database
 				assert.Equal(2, pageStats.Free)    // unused pages (from delete)
 				assert.Equal(1024, pageStats.Size) // bytes/page
 			}
@@ -568,7 +568,7 @@ func testApiOptimize(db SyncApi, t *testing.T) {
 			assert.Equal(3, purged)
 			stats, err := db.Usage()
 			if assert.NoError(err) {
-				assert.Equal(25, stats.FreePercent()) // we know this from a previous test ;)
+				assert.Equal(23, stats.FreePercent()) // we know this from a previous test ;)
 				vac, err := db.Optimize(20)
 				assert.NoError(err)
 				assert.True(vac)


### PR DESCRIPTION
- Make the 11 common collections have static Ids
- db.GetCollectionId() will return the static Id numbers if
  collection name is one of the common ones (reduces db/disk io)
- add tests to ensure proper behaviour
- update context tests for new behaviour
