### PR TITLE
Add caching to info/* API endpoints, fix bug in server.go

### DIFF
--- a/api/context_cache.go
+++ b/api/context_cache.go
@@ -1,0 +1,195 @@
+package api
+
+import "sync"
+
+// cache stores collection data reduce disk IO. The api
+// endpoints: info/collections, info/collection_usage,
+// info/collection_counts are all map[string]int. This
+// can be squashed to []int, like: [<name idx>, int val, ...]
+// to reduce memory requirements
+
+type colMap map[string]int
+type colValues []int
+type usercache struct {
+	// last time the user's db was modified
+	modified int
+
+	infoCollections      colValues
+	infoCollectionCounts colValues
+	infoCollectionUsage  colValues
+	infoQuota            colValues
+}
+
+// the ram requirements to cache a user's collection information can be
+// drastically reduced since there aren't that many unique collection
+// names and we can just use ints to point to an list of strings
+type squasher struct {
+	sync.Mutex
+	names    map[string]int
+	namesrev map[int]*string
+}
+
+func NewSquasher() *squasher {
+	return &squasher{
+		names:    make(map[string]int),
+		namesrev: make(map[int]*string),
+	}
+}
+
+// squash reduces a colMap to a colValues
+func (s *squasher) squash(d colMap) colValues {
+	elements := len(d) * 2
+	cValues := make(colValues, elements, elements)
+	i := 0
+	for k, v := range d {
+		s.Lock()
+		var nameIndex int
+		var ok bool
+		if nameIndex, ok = s.names[k]; !ok {
+			nameIndex = len(s.namesrev)
+			key := k                     // copy the string
+			s.namesrev[nameIndex] = &key // pointer to the string
+			s.names[key] = nameIndex
+		}
+		s.Unlock()
+
+		cValues[i] = nameIndex
+		i = i + 1
+		cValues[i] = v
+		i = i + 1
+	}
+
+	return cValues
+}
+
+func (s *squasher) expand(v colValues) (m colMap) {
+	size := len(v) / 2
+	m = make(colMap, size)
+	for i := 0; i < len(v); i += 2 {
+		key := *s.namesrev[v[i]]
+		m[key] = v[i+1]
+	}
+	return
+}
+
+func NewCollectionCache() *collectionCache {
+	return &collectionCache{
+		squasher: squasher{
+			names:    make(map[string]int),
+			namesrev: make(map[int]*string),
+		},
+		data: make(map[string]*usercache),
+	}
+}
+
+type collectionCache struct {
+	sync.RWMutex
+	squasher
+
+	data map[string]*usercache
+}
+
+// Clear wipes all cached data for a user
+func (c *collectionCache) Clear(uid string) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.data, uid)
+}
+
+func (c *collectionCache) GetModified(uid string) int {
+	c.RLock()
+	defer c.RUnlock()
+
+	if d, ok := c.data[uid]; ok {
+		return d.modified
+	}
+	return 0
+}
+
+func (c *collectionCache) SetModified(uid string, modified int) {
+	c.Lock()
+	defer c.Unlock()
+
+	if c.data[uid] == nil {
+		c.data[uid] = &usercache{
+			modified: modified,
+		}
+	} else {
+		c.data[uid].modified = modified
+	}
+}
+
+func (c *collectionCache) GetInfoCollections(uid string) colMap {
+	c.RLock()
+	defer c.RUnlock()
+
+	if d, ok := c.data[uid]; ok {
+		if d.infoCollections != nil {
+			return c.expand(d.infoCollections)
+		}
+	}
+
+	return nil
+}
+
+func (c *collectionCache) SetInfoCollections(uid string, d colMap) {
+	c.Lock()
+	defer c.Unlock()
+	if c.data[uid] == nil {
+		c.data[uid] = &usercache{
+			infoCollections: c.squash(d),
+		}
+	} else {
+		c.data[uid].infoCollections = c.squash(d)
+	}
+}
+
+func (c *collectionCache) GetInfoCollectionUsage(uid string) colMap {
+	c.RLock()
+	defer c.RUnlock()
+
+	if d, ok := c.data[uid]; ok {
+		if d.infoCollectionUsage != nil {
+			return c.expand(d.infoCollectionUsage)
+		}
+	}
+
+	return nil
+}
+
+func (c *collectionCache) SetInfoCollectionUsage(uid string, d colMap) {
+	c.Lock()
+	defer c.Unlock()
+	if c.data[uid] == nil {
+		c.data[uid] = &usercache{
+			infoCollectionUsage: c.squash(d),
+		}
+	} else {
+		c.data[uid].infoCollectionUsage = c.squash(d)
+	}
+}
+
+func (c *collectionCache) GetInfoCollectionCounts(uid string) colMap {
+	c.RLock()
+	defer c.RUnlock()
+
+	if d, ok := c.data[uid]; ok {
+		if d.infoCollectionCounts != nil {
+			return c.expand(d.infoCollectionCounts)
+		}
+	}
+
+	return nil
+}
+
+func (c *collectionCache) SetInfoCollectionCounts(uid string, d colMap) {
+	c.Lock()
+	defer c.Unlock()
+	if c.data[uid] == nil {
+		c.data[uid] = &usercache{
+			infoCollectionCounts: c.squash(d),
+		}
+	} else {
+		c.data[uid].infoCollectionCounts = c.squash(d)
+	}
+}

--- a/api/context_cache_test.go
+++ b/api/context_cache_test.go
@@ -1,0 +1,145 @@
+package api
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func gettestmap() colMap {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	return colMap{
+		"bookmarks": r.Int(),
+		"passwords": r.Int(),
+		"meta":      r.Int(),
+		"other":     r.Int(),
+	}
+}
+
+func TestSquasherSquashExpand(t *testing.T) {
+	assert := assert.New(t)
+
+	s := NewSquasher()
+	m := colMap{
+		"bookmarks": 100,
+		"passwords": 200,
+		"meta":      300,
+		"other":     400,
+	}
+
+	// squash and expand it and make sure fidelity is maintained
+	d := s.expand(s.squash(m))
+
+	assert.Equal(100, d["bookmarks"])
+	assert.Equal(200, d["passwords"])
+	assert.Equal(300, d["meta"])
+	assert.Equal(400, d["other"])
+}
+
+func BenchmarkSquasherSquash(b *testing.B) {
+	s := NewSquasher()
+	m := gettestmap()
+	for i := 0; i < b.N; i++ {
+		s.squash(m)
+	}
+}
+
+func BenchmarkSquasherExpand(b *testing.B) {
+	s := NewSquasher()
+	m := s.squash(gettestmap())
+
+	for i := 0; i < b.N; i++ {
+		s.expand(m)
+	}
+}
+
+func TestCollectionCacheModified(t *testing.T) {
+
+	assert := assert.New(t)
+	c := NewCollectionCache()
+	uid := "10"
+
+	assert.Equal(0, c.GetModified(uid))
+	c.SetModified(uid, 10)
+	assert.Equal(10, c.GetModified(uid))
+
+}
+
+func TestCollectionCacheInfoCollections(t *testing.T) {
+	assert := assert.New(t)
+	c := NewCollectionCache()
+
+	uid := "10"
+	m := gettestmap()
+	c.SetInfoCollections(uid, m)
+	m2 := c.GetInfoCollections(uid)
+	if !assert.NotNil(m2) {
+		return
+	}
+
+	assert.Equal(m, m2)
+
+	c.Clear(uid)
+	assert.Nil(c.GetInfoCollections(uid))
+}
+
+func TestCollectionCacheInfoCollectionUsageC(t *testing.T) {
+	assert := assert.New(t)
+	c := NewCollectionCache()
+
+	uid := "10"
+	m := gettestmap()
+	c.SetInfoCollectionUsage(uid, m)
+	m2 := c.GetInfoCollectionUsage(uid)
+	if !assert.NotNil(m2) {
+		return
+	}
+
+	assert.Equal(m, m2)
+
+	c.Clear(uid)
+	assert.Nil(c.GetInfoCollectionUsage(uid))
+}
+
+func TestCollectionCacheInfoCollectionCounts(t *testing.T) {
+	assert := assert.New(t)
+	c := NewCollectionCache()
+
+	uid := "10"
+	m := gettestmap()
+	c.SetInfoCollectionCounts(uid, m)
+	m2 := c.GetInfoCollectionCounts(uid)
+	if !assert.NotNil(m2) {
+		return
+	}
+
+	assert.Equal(m, m2)
+	c.Clear(uid)
+	assert.Nil(c.GetInfoCollectionCounts(uid))
+}
+
+func TestCollectionCacheSetAll(t *testing.T) {
+	assert := assert.New(t)
+	c := NewCollectionCache()
+	uid := "10"
+	m0 := gettestmap()
+	m1 := gettestmap()
+	m2 := gettestmap()
+
+	c.SetInfoCollections(uid, m0)
+	c.SetInfoCollectionCounts(uid, m1)
+	c.SetInfoCollectionUsage(uid, m2)
+
+	assert.Equal(m0, c.GetInfoCollections(uid))
+	assert.Equal(m1, c.GetInfoCollectionCounts(uid))
+	assert.Equal(m2, c.GetInfoCollectionUsage(uid))
+
+	c.Clear(uid)
+
+	assert.Nil(c.GetInfoCollections(uid))
+	assert.Nil(c.GetInfoCollectionCounts(uid))
+	assert.Nil(c.GetInfoCollectionUsage(uid))
+}

--- a/api/util.go
+++ b/api/util.go
@@ -65,7 +65,7 @@ func extractModifiedTimestamp(r *http.Request) (ts int, headerType XModHeader, e
 	return 0, X_TS_HEADER_NONE, nil
 }
 
-// checkModified will check the provided modified timestamp against
+// sentNotModified will check the provided modified timestamp against
 // either the X-If-Modified-Since or X-If-Unmodified-Since and return
 // true if it wrote to w
 func sentNotModified(w http.ResponseWriter, r *http.Request, modified int) (sentResponse bool) {
@@ -89,4 +89,15 @@ func sentNotModified(w http.ResponseWriter, r *http.Request, modified int) (sent
 	}
 
 	return false
+}
+
+func setCacheHeader(w http.ResponseWriter, status cacheStatus) {
+	switch status {
+	case CACHE_HIT:
+		w.Header().Set("X-Weave-Cache", "HIT")
+	case CACHE_MISS:
+		w.Header().Set("X-Weave-Cache", "MISS")
+	default:
+		w.Header().Set("X-Weave-Cache", "NONE")
+	}
 }

--- a/server.go
+++ b/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -28,13 +29,9 @@ func init() {
 
 func main() {
 
-	// for now we will use a fixed number of pools
-	// and spread config.MaxOpenFiles evenly among them
 	numPools := uint16(8)
-	cacheSize := int(uint16(config.MaxOpenFiles) / numPools)
-
 	dispatch, err := syncstorage.NewDispatch(
-		numPools, config.DataDir, syncstorage.TwoLevelPath, cacheSize)
+		numPools, config.DataDir, 5*time.Minute)
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
- add caching to info/collections
- cache DB modified time, info/collection_usage
- add caching to info/collection_counts
- remove collectionCache.*InfoQuota
- add caching to info/quota
- Fix bug in server.go for new syncstorage.Dispatch interface
