### PR TITLE
add circle building of binary and docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM busybox:1.24.2
+
+WORKDIR /app
+ENTRYPOINT /app/go-syncstorage
+
+RUN addgroup -g 10001 app && \
+    adduser -G app -u 10001 -D -h /app -s /sbin/nologin app
+
+COPY version.json /app/version.json
+COPY go-syncstorage /app/go-syncstorage
+
+USER app

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,68 @@
+machine:
+  environment:
+    IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+
+  services:
+    - docker
+
+dependencies:
+  #cache_directories:
+  #  - "~/docker"
+
+  override:
+    - docker info
+
+    # our build container
+    - docker pull golang:1.6
+
+    # create a version.json
+    - printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" > version.json
+    - cp version.json $CIRCLE_ARTIFACTS
+
+test:
+  override:
+    - docker run -it -v "$PWD:/go/src/$IMPORT_PATH" -w "/go/src/$IMPORT_PATH" golang:1.6 go test -v ./token ./syncstorage ./api
+
+    # build a static binary and package it into a busybox image
+    # used by deployment below
+    - docker run -it -v "$PWD:/go/src/$IMPORT_PATH" -w "/go/src/$IMPORT_PATH" golang:1.6 go build --ldflags '-extldflags "-static"' .
+    
+    # put these here since the build is shared by all deployments
+    - docker build -t "app:build" .
+    - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
+
+deployment:
+  # this is just for dev
+  hub_all:
+    branch: /.*/
+    commands:
+      - test -e $CIRCLE_ARTIFACTS/bin || mkdir -p $CIRCLE_ARTIFACTS/bin
+      - cp go-syncstorage $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1
+      - sha256sum $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1 | tee $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1-shasum256.txt
+
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag app:build ${DOCKERHUB_REPO}:unstable
+      - docker push ${DOCKERHUB_REPO}:unstable
+
+  hub_latest:
+    branch: master
+    commands:
+      - test -e $CIRCLE_ARTIFACTS/bin || mkdir -p $CIRCLE_ARTIFACTS/bin
+      - cp go-syncstorage $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1
+      - sha256sum $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1 | tee $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1-shasum256.txt
+
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag app:build ${DOCKERHUB_REPO}:latest
+      - docker push ${DOCKERHUB_REPO}:latest
+
+  hub_releases:
+    tag: /.*/
+    commands:
+      - test -e $CIRCLE_ARTIFACTS/bin || mkdir -p $CIRCLE_ARTIFACTS/bin
+      - cp go-syncstorage "$CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_TAG"
+      - sha256sum $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_TAG | tee $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_TAG
+      - sha256sum $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_TAG | tee $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_TAG-shasum256.txt
+
+      - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+      - docker tag app:build ${DOCKERHUB_REPO}:${CIRCLE_TAG}
+      - docker push ${DOCKERHUB_REPO}:${CIRCLE_TAG}


### PR DESCRIPTION
- circleci builds a linux-amd64 binary 
- circleci builds a docker (busybox based) container 
- sha256 sums are recorded for later verification 
- Fixes #4 and #5 
