### PR TITLE
fix #62 switch sqlite3 to WAL mode (DO NOT MERGE)

### DIFF
--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -141,7 +141,20 @@ func (d *DB) Open() (err error) {
 		return
 	}
 
-	// initialize and or update tables if required
+	// settings to apply to the database
+	pragmas := []string{
+		"PRAGMA page_size=4096;",
+		"PRAGMA journal_mode=WAL;",
+
+		// do an fsync() on every commit
+		"PRAGMA synchronous=FULL;",
+	}
+
+	for _, p := range pragmas {
+		if _, err = d.db.Exec(p); err != nil {
+			return err
+		}
+	}
 
 	// Initialize Schema 0 if it doesn't exist
 	sqlCheck := "SELECT name from sqlite_master WHERE type='table' AND name=?"

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -2,7 +2,6 @@ package syncstorage
 
 import (
 	"io/ioutil"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -26,14 +25,10 @@ func getTestDB() (*DB, error) {
 	return db, nil
 }
 
-func removeTestDB(d *DB) error {
-	return os.Remove(d.Path)
-}
-
 func TestNewDB(t *testing.T) {
-	db, err := getTestDB()
+	_, err := getTestDB()
 	assert.NoError(t, err)
-	defer removeTestDB(db)
+
 }
 
 // TestStaticCollectionId ensures common collection
@@ -111,7 +106,6 @@ func TestBsoExists(t *testing.T) {
 	assert := assert.New(t)
 
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	tx, err := db.db.Begin()
 	assert.NoError(err)
@@ -141,7 +135,6 @@ func TestBsoExists(t *testing.T) {
 
 func TestUpdateBSOReturnsExpectedError(t *testing.T) {
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	tx, _ := db.db.Begin()
 	defer tx.Rollback()
@@ -157,7 +150,6 @@ func TestPrivateUpdateBSOSuccessfullyUpdatesSingleValues(t *testing.T) {
 
 	assert := assert.New(t)
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	tx, _ := db.db.Begin()
 
@@ -215,7 +207,6 @@ func TestPrivateUpdateBSOModifiedNotChangedOnTTLTouch(t *testing.T) {
 	assert := assert.New(t)
 
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	tx, _ := db.db.Begin()
 
@@ -253,7 +244,6 @@ func TestPrivatePutBSOUpdates(t *testing.T) {
 	assert := assert.New(t)
 
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	tx, _ := db.db.Begin()
 	defer tx.Rollback()
@@ -285,7 +275,6 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 	assert := assert.New(t)
 
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	tx, _ := db.db.Begin()
 	defer tx.Rollback()
@@ -361,7 +350,6 @@ func TestPrivateGetBSOsNewer(t *testing.T) {
 	assert := assert.New(t)
 
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	tx, _ := db.db.Begin()
 	defer tx.Rollback()
@@ -416,7 +404,6 @@ func TestPrivateGetBSOsSort(t *testing.T) {
 	assert := assert.New(t)
 
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	tx, _ := db.db.Begin()
 	defer tx.Rollback()
@@ -464,21 +451,20 @@ func TestPrivateGetBSOsSort(t *testing.T) {
 func TestLastModified(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiLastModified(db, t)
 }
 
 func TestGetCollectionId(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiGetCollectionId(db, t)
 }
 
 func TestGetCollectionModified(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
 
 	testApiGetCollectionModified(db, t)
 }
@@ -486,116 +472,116 @@ func TestGetCollectionModified(t *testing.T) {
 func TestCreateCollection(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiCreateCollection(db, t)
 }
 
 func TestDeleteCollection(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiDeleteCollection(db, t)
 }
 
 func TestDeleteEverything(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiDeleteEverything(db, t)
 }
 
 func TestTouchCollection(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiTouchCollection(db, t)
 }
 
 func TestInfoCollections(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiInfoCollections(db, t)
 }
 
 func TestInfoCollectionUsage(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiInfoCollectionUsage(db, t)
 }
 
 func TestInfoCollectionCounts(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiInfoCollectionCounts(db, t)
 }
 
 func TestPublicPostBSOs(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiPostBSOs(db, t)
 }
 
 func TestPublicPutBSO(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiPutBSO(db, t)
 }
 
 func TestPublicGetBSO(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiGetBSO(db, t)
 }
 
 func TestPublicGetBSOs(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiGetBSOs(db, t)
 }
 func TestPublicGetBSOModified(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiGetBSOModified(db, t)
 }
 
 func TestDeleteBSO(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiDeleteBSO(db, t)
 }
 func TestDeleteBSOs(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiDeleteBSOs(db, t)
 }
 
 func TestPurgeExpired(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiPurgeExpired(db, t)
 }
 
 func TestUsageStats(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiUsageStats(db, t)
 }
 
 func TestOptimize(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()
-	defer removeTestDB(db)
+
 	testApiOptimize(db, t)
 }

--- a/syncstorage/syncapi_test.go
+++ b/syncstorage/syncapi_test.go
@@ -502,26 +502,29 @@ func testApiDeleteBSOs(db SyncApi, t *testing.T) {
 func testApiUsageStats(db SyncApi, t *testing.T) {
 	assert := assert.New(t)
 	cId := 1
-	payload := strings.Repeat("x", 1024)
+	payload := strings.Repeat("x", 1024*4)
 
 	create := PostBSOInput{
 		NewPutBSOInput("b0", &payload, Int(10), nil),
 		NewPutBSOInput("b1", &payload, Int(10), nil),
 		NewPutBSOInput("b2", &payload, Int(10), nil),
+		NewPutBSOInput("b3", &payload, Int(10), nil),
+		NewPutBSOInput("b4", &payload, Int(10), nil),
+		NewPutBSOInput("b5", &payload, Int(10), nil),
 	}
 
 	_, err := db.PostBSOs(cId, create)
 	if assert.NoError(err) {
 
-		_, err = db.DeleteBSOs(cId, "b0", "b1")
+		_, err = db.DeleteBSOs(cId, "b0", "b1", "b3")
 		if assert.NoError(err) {
 			pageStats, err := db.Usage()
 			if assert.NoError(err) {
 
 				// numbers pulled from previous tests
-				assert.Equal(13, pageStats.Total)  // total pages in database
-				assert.Equal(2, pageStats.Free)    // unused pages (from delete)
-				assert.Equal(1024, pageStats.Size) // bytes/page
+				assert.Equal(14, pageStats.Total)  // total pages in database
+				assert.Equal(3, pageStats.Free)    // unused pages (from delete)
+				assert.Equal(4096, pageStats.Size) // bytes/page
 			}
 		}
 	}
@@ -552,7 +555,7 @@ func testApiPurgeExpired(db SyncApi, t *testing.T) {
 func testApiOptimize(db SyncApi, t *testing.T) {
 	assert := assert.New(t)
 	cId := 1
-	payload := strings.Repeat("x", 1024)
+	payload := strings.Repeat("x", 4096)
 
 	create := PostBSOInput{
 		NewPutBSOInput("b0", &payload, Int(10), Int(1)),
@@ -568,7 +571,7 @@ func testApiOptimize(db SyncApi, t *testing.T) {
 			assert.Equal(3, purged)
 			stats, err := db.Usage()
 			if assert.NoError(err) {
-				assert.Equal(23, stats.FreePercent()) // we know this from a previous test ;)
+				assert.Equal(27, stats.FreePercent()) // we know this from a previous test ;)
 				vac, err := db.Optimize(20)
 				assert.NoError(err)
 				assert.True(vac)


### PR DESCRIPTION
Some things that may prevent this PR from ever merging: 
- WAL mode writes a `-wal` and a `-shm` per database. These are the write ahead log and the shared memory file respectively 
- the WAL checkpoint defaults to 1000 pages (1000 \* 4096 page size), so about 4MB. This might be a lot of data before an automatic checkpoint is done. This means reads must go though a decent amount of WAL, which may have an impact on read performance
