### PR TITLE
Refactor api context caching to use bigcache instead of a map 

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -21,6 +21,7 @@ var apiDebug = Debug("syncapi")
 var authDebug = Debug("syncapi:auth")
 
 var (
+	EmptyData            = make([]byte, 0, 0)
 	ErrMissingBSOId      = errors.New("Missing BSO Id")
 	ErrInvalidPostJSON   = errors.New("Malformed POST JSON")
 	ErrRequireSecretList = errors.New("Require secrets list")

--- a/api/context_cache_test.go
+++ b/api/context_cache_test.go
@@ -1,12 +1,24 @@
 package api
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var (
+	benchUid  = "12345"
+	benchData = make(map[string]int)
+)
+
+func init() {
+	for i := 0; i < 10; i++ {
+		benchData[fmt.Sprintf("collect%d", i)] = i
+	}
+}
 
 func gettestmap() colMap {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -39,25 +51,7 @@ func TestSquasherSquashExpand(t *testing.T) {
 	assert.Equal(400, d["other"])
 }
 
-func BenchmarkSquasherSquash(b *testing.B) {
-	s := NewSquasher()
-	m := gettestmap()
-	for i := 0; i < b.N; i++ {
-		s.squash(m)
-	}
-}
-
-func BenchmarkSquasherExpand(b *testing.B) {
-	s := NewSquasher()
-	m := s.squash(gettestmap())
-
-	for i := 0; i < b.N; i++ {
-		s.expand(m)
-	}
-}
-
 func TestCollectionCacheModified(t *testing.T) {
-
 	assert := assert.New(t)
 	c := NewCollectionCache()
 	uid := "10"
@@ -65,6 +59,10 @@ func TestCollectionCacheModified(t *testing.T) {
 	assert.Equal(0, c.GetModified(uid))
 	c.SetModified(uid, 10)
 	assert.Equal(10, c.GetModified(uid))
+	c.SetModified(uid, 11)
+	assert.Equal(11, c.GetModified(uid))
+	c.Clear(uid)
+	assert.Equal(0, c.GetModified(uid))
 
 }
 
@@ -142,4 +140,77 @@ func TestCollectionCacheSetAll(t *testing.T) {
 	assert.Nil(c.GetInfoCollections(uid))
 	assert.Nil(c.GetInfoCollectionCounts(uid))
 	assert.Nil(c.GetInfoCollectionUsage(uid))
+}
+
+func BenchmarkSquasherSquash(b *testing.B) {
+	s := NewSquasher()
+	m := gettestmap()
+	for i := 0; i < b.N; i++ {
+		s.squash(m)
+	}
+}
+
+func BenchmarkSquasherExpand(b *testing.B) {
+	s := NewSquasher()
+	m := s.squash(gettestmap())
+
+	for i := 0; i < b.N; i++ {
+		s.expand(m)
+	}
+}
+
+func BenchmarkCacheKey(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		cacheKey("A", "BCDEFGHIJK")
+	}
+}
+func BenchmarkCollectionCacheClear(b *testing.B) {
+	cache := NewCollectionCache()
+	for i := 0; i < b.N; i++ {
+		cache.Clear(benchUid)
+	}
+}
+func BenchmarkCollectionCacheSetInfoCollections(b *testing.B) {
+	cache := NewCollectionCache()
+	for i := 0; i < b.N; i++ {
+		cache.SetInfoCollections(benchUid, benchData)
+	}
+}
+func BenchmarkCollectionCacheGetInfoCollections(b *testing.B) {
+	cache := NewCollectionCache()
+	cache.SetInfoCollections(benchUid, benchData)
+
+	for i := 0; i < b.N; i++ {
+		cache.GetInfoCollections(benchUid)
+	}
+}
+
+func BenchmarkCollectionCacheSetInfoCollectionUsage(b *testing.B) {
+	cache := NewCollectionCache()
+	for i := 0; i < b.N; i++ {
+		cache.SetInfoCollectionUsage(benchUid, benchData)
+	}
+}
+func BenchmarkCollectionCacheGetInfoCollectionUsage(b *testing.B) {
+	cache := NewCollectionCache()
+	cache.SetInfoCollectionUsage(benchUid, benchData)
+
+	for i := 0; i < b.N; i++ {
+		cache.GetInfoCollectionUsage(benchUid)
+	}
+}
+
+func BenchmarkCollectionCacheSetInfoCollectionCounts(b *testing.B) {
+	cache := NewCollectionCache()
+	for i := 0; i < b.N; i++ {
+		cache.SetInfoCollectionCounts(benchUid, benchData)
+	}
+}
+func BenchmarkCollectionCacheGetInfoCollectionCounts(b *testing.B) {
+	cache := NewCollectionCache()
+	cache.SetInfoCollectionCounts(benchUid, benchData)
+
+	for i := 0; i < b.N; i++ {
+		cache.GetInfoCollectionCounts(benchUid)
+	}
 }

--- a/api/context_hawk.go
+++ b/api/context_hawk.go
@@ -120,13 +120,6 @@ func (c *Context) hawk(h syncApiHandler) http.HandlerFunc {
 	})
 }
 
-// hawkNonceCheck returns true when nonce is unique, false otherwise
-var (
-	// we don't really need to store a value in the nonce
-	// cache, so just reuse the same slice
-	emptyValue = make([]byte, 0)
-)
-
 func (c *Context) hawkNonceNotFound(nonce string, t time.Time, creds *hawk.Credentials) bool {
 	if c.DisableHawk {
 		return true
@@ -158,7 +151,7 @@ func (c *Context) hawkNonceNotFound(nonce string, t time.Time, creds *hawk.Crede
 
 	key := h.Sum(nil)
 	if _, err := c.hawkCache.Get(key); err == freecache.ErrNotFound {
-		c.hawkCache.Set(key, emptyValue, 60 /* seconds */)
+		c.hawkCache.Set(key, EmptyData, 60 /* seconds */)
 		return true
 	}
 

--- a/vendor.yml
+++ b/vendor.yml
@@ -1,6 +1,8 @@
 vendors:
 - path: github.com/Sirupsen/logrus
   rev: 081307d9bc1364753142d5962fc1d795c742baaf
+- path: github.com/allegro/bigcache
+  rev: 662723b6a7d4a136649111e3c6728e6215c096df
 - path: github.com/coocood/freecache
   rev: 1aa53c26cb85c33eef6d832305447982e95f844c
 - path: github.com/davecgh/go-spew

--- a/vendor/github.com/allegro/bigcache/.travis.yml
+++ b/vendor/github.com/allegro/bigcache/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+
+go:
+  - 1.6
+  - tip
+
+before_install:
+  - go get github.com/modocache/gover
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+  - go get golang.org/x/tools/cmd/goimports
+  - go get github.com/golang/lint/golint
+script:
+  - gofiles=$(find ./ -name '*.go') && [ -z "$gofiles" ] || unformatted=$(goimports -l $gofiles) && [ -z "$unformatted" ] || (echo >&2 "Go files must be formatted with gofmt. Following files has problem:\n $unformatted" && false)
+  - golint ./... # This won't break the build, just show warnings
+  - go test -coverprofile=web.coverprofile ./queue
+  - go test -coverprofile=main.coverprofile
+  - $HOME/gopath/bin/gover
+  - $HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service travis-ci

--- a/vendor/github.com/allegro/bigcache/LICENSE
+++ b/vendor/github.com/allegro/bigcache/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/allegro/bigcache/README.md
+++ b/vendor/github.com/allegro/bigcache/README.md
@@ -1,0 +1,133 @@
+# BigCache [![Build Status](https://travis-ci.org/allegro/bigcache.svg?branch=master)](https://travis-ci.org/allegro/bigcache)[![Coverage Status](https://coveralls.io/repos/github/allegro/bigcache/badge.svg?branch=master)](https://coveralls.io/github/allegro/bigcache?branch=master)[![GoDoc](https://godoc.org/github.com/allegro/bigcache?status.svg)](https://godoc.org/github.com/allegro/bigcache)
+
+Fast, concurrent, evicting in-memory cache written to keep big number of entries without impact on performance.
+BigCache keeps entries on heap but omits GC for them. To achieve that operations on bytes arrays take place,
+therefore entries (de)serialization in front of the cache will be needed in most use cases.
+
+## Usage
+
+### Simple initialization
+
+```go
+import "github.com/allegro/bigcache"
+
+cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(10 * time.Minute))
+
+cache.Set("my-unique-key", []byte("value"))
+
+entry, _ := cache.Get("my-unique-key")
+fmt.Println(string(entry))
+```
+
+### Custom initialization
+
+When cache load can be predicted in advance then it is better to use custom initialization because additional memory
+allocation can be avoided in that way.
+
+```go
+import (
+	"log"
+
+	"github.com/allegro/bigcache"
+)
+
+config := bigcache.Config {
+		// number of shards (must be a power of 2)
+		Shards: 1024,
+		// time after which entry can be evicted
+		LifeWindow: 10 * time.Minute,
+		// rps * lifeWindow, used only in initial memory allocation
+		MaxEntriesInWindow: 1000 * 10 * 60,
+		// max entry size in bytes, used only in initial memory allocation
+		MaxEntrySize: 500,
+		// prints information about additional memory allocation
+		Verbose: true,
+		// cache will not allocate more memory than this limit, value in MB
+		// if value is reached then the oldest entries can be overridden for the new ones
+		// 0 value means no size limit
+		HardMaxCacheSize: 8192,
+	}
+
+cache, initErr := bigcache.NewBigCache(config)
+if initErr != nil {
+	log.Fatal(initErr)
+}
+
+cache.Set("my-unique-key", []byte("value"))
+
+if entry, err := cache.Get("my-unique-key"); err == nil {
+	fmt.Println(string(entry))
+}
+```
+
+## Benchmarks
+
+Three caches were compared: bigcache, [freecache](https://github.com/coocood/freecache) and map.
+Benchmark tests were made on MacBook Pro (3 GHz Processor Intel Core i7, 16GB Memory).
+
+### Writes and reads
+
+```
+cd caches_bench; go test -bench=. -benchtime=10s ./...
+
+BenchmarkMapSet-4              	10000000	      1430 ns/op
+BenchmarkFreeCacheSet-4        	20000000	      1115 ns/op
+BenchmarkBigCacheSet-4         	20000000	       873 ns/op
+BenchmarkMapGet-4              	30000000	       558 ns/op
+BenchmarkFreeCacheGet-4        	20000000	       973 ns/op
+BenchmarkBigCacheGet-4         	20000000	       737 ns/op
+BenchmarkBigCacheSetParallel-4 	30000000	       545 ns/op
+BenchmarkFreeCacheSetParallel-4	20000000	       654 ns/op
+BenchmarkBigCacheGetParallel-4 	50000000	       426 ns/op
+BenchmarkFreeCacheGetParallel-4	50000000	       715 ns/op
+```
+
+Writes and reads in bigcache are faster than in freecache.
+Writes to map are the slowest.
+
+### GC pause time
+
+```
+cd caches_bench; go run caches_gc_overhead_comparsion.go
+
+Number of entries:  20000000
+GC pause for bigcache:  27.81671ms
+GC pause for freecache:  30.218371ms
+GC pause for map:  11.590772251s
+```
+
+Test shows how long are the GC pauses for caches filled with 20mln of entries.
+Bigcache and freecache have very similar GC pause time.
+It is clear that both reduce GC overhead in contrast to map
+which GC pause time took more than 10 seconds.
+
+## How it works
+
+BigCache relies on optimization presented in 1.5 version of Go ([issue-9477](https://github.com/golang/go/issues/9477)).
+This optimization states that if map without pointers in keys and values is used then GC will omit it’s content.
+Therefore BigCache uses `map[uint64]uint32` where keys are hashed and values are offsets of entries.
+
+Entries are kept in bytes array, to omit GC again.
+Bytes array size can grow to gigabytes without impact on performance
+because GC will only see single pointer to it.
+
+## Bigcache vs Freecache
+Both caches provide the same core features but they reduce GC overhead in different ways.
+Bigcache relies on `map[uint64]uint32`, freecache implements its own mapping built on
+slices to reduce number of pointers.
+
+Results from benchmark tests are presented above.
+One of the advantage of bigcache over freecache is that you don’t need to know
+the size of the cache in advance, because when bigcache is full,
+it can allocate additional memory for new entries instead of
+overwriting existing ones as freecache does currently.
+However hard max size in bigcache also can be set, check [HardMaxCacheSize](https://godoc.org/github.com/allegro/bigcache#Config).
+
+
+## More
+
+Bigcache genesis is described in allegro.tech blog post: [writing a very fast cache service in Go](http://allegro.tech/2016/03/writing-fast-cache-service-in-go.html)
+
+## License
+
+BigCache is released under the Apache 2.0 license (see [LICENSE](LICENSE))

--- a/vendor/github.com/allegro/bigcache/bigcache.go
+++ b/vendor/github.com/allegro/bigcache/bigcache.go
@@ -1,0 +1,168 @@
+package bigcache
+
+import (
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/allegro/bigcache/queue"
+)
+
+const (
+	minimumEntriesInShard = 10 // Minimum number of entries in single shard
+)
+
+// BigCache is fast, concurrent, evicting cache created to keep big number of entries without impact on performance.
+// It keeps entries on heap but omits GC for them. To achieve that operations on bytes arrays take place,
+// therefore entries (de)serialization in front of the cache will be needed in most use cases.
+type BigCache struct {
+	shards       []*cacheShard
+	lifeWindow   uint64
+	clock        clock
+	hash         Hasher
+	config       Config
+	shardMask    uint64
+	maxShardSize uint32
+}
+
+type cacheShard struct {
+	hashmap     map[uint64]uint32
+	entries     queue.BytesQueue
+	lock        sync.RWMutex
+	entryBuffer []byte
+}
+
+// NewBigCache initialize new instance of BigCache
+func NewBigCache(config Config) (*BigCache, error) {
+	return newBigCache(config, &systemClock{})
+}
+
+func newBigCache(config Config, clock clock) (*BigCache, error) {
+
+	if !isPowerOfTwo(config.Shards) {
+		return nil, fmt.Errorf("Shards number must be power of two")
+	}
+
+	if config.Hasher == nil {
+		config.Hasher = newDefaultHasher()
+	}
+
+	maxShardSize := 0
+	if config.HardMaxCacheSize > 0 {
+		maxShardSize = convertMBToBytes(config.HardMaxCacheSize) / config.Shards
+	}
+
+	cache := &BigCache{
+		shards:       make([]*cacheShard, config.Shards),
+		lifeWindow:   uint64(config.LifeWindow.Seconds()),
+		clock:        clock,
+		hash:         config.Hasher,
+		config:       config,
+		shardMask:    uint64(config.Shards - 1),
+		maxShardSize: uint32(maxShardSize),
+	}
+
+	initShardSize := max(config.MaxEntriesInWindow/config.Shards, minimumEntriesInShard)
+	for i := 0; i < config.Shards; i++ {
+		cache.shards[i] = &cacheShard{
+			hashmap:     make(map[uint64]uint32, initShardSize),
+			entries:     *queue.NewBytesQueue(initShardSize*config.MaxEntrySize, maxShardSize, config.Verbose),
+			entryBuffer: make([]byte, config.MaxEntrySize+headersSizeInBytes),
+		}
+	}
+
+	return cache, nil
+}
+
+func isPowerOfTwo(number int) bool {
+	return (number & (number - 1)) == 0
+}
+
+// Get reads entry for the key
+func (c *BigCache) Get(key string) ([]byte, error) {
+	hashedKey := c.hash.Sum64(key)
+	shard := c.getShard(hashedKey)
+	shard.lock.RLock()
+	defer shard.lock.RUnlock()
+
+	itemIndex := shard.hashmap[hashedKey]
+
+	if itemIndex == 0 {
+		return nil, notFound(key)
+	}
+
+	wrappedEntry, err := shard.entries.Get(int(itemIndex))
+	if err != nil {
+		return nil, err
+	}
+	if entryKey := readKeyFromEntry(wrappedEntry); key != entryKey {
+		if c.config.Verbose {
+			log.Printf("Collision detected. Both %q and %q have the same hash %x", key, entryKey, hashedKey)
+		}
+		return nil, notFound(key)
+	}
+	return readEntry(wrappedEntry), nil
+}
+
+// Set saves entry under the key
+func (c *BigCache) Set(key string, entry []byte) error {
+	hashedKey := c.hash.Sum64(key)
+	shard := c.getShard(hashedKey)
+	shard.lock.Lock()
+	defer shard.lock.Unlock()
+
+	currentTimestamp := uint64(c.clock.epoch())
+
+	if previousIndex := shard.hashmap[hashedKey]; previousIndex != 0 {
+		if previousEntry, err := shard.entries.Get(int(previousIndex)); err == nil {
+			resetKeyFromEntry(previousEntry)
+		}
+	}
+
+	if oldestEntry, err := shard.entries.Peek(); err == nil {
+		c.onEvict(oldestEntry, currentTimestamp, shard.removeOldestEntry)
+	}
+
+	w := wrapEntry(currentTimestamp, hashedKey, key, entry, &shard.entryBuffer)
+
+	for {
+		if index, err := shard.entries.Push(w); err == nil {
+			shard.hashmap[hashedKey] = uint32(index)
+			return nil
+		} else if shard.removeOldestEntry() != nil {
+			return fmt.Errorf("Entry is bigger than max shard size.")
+		}
+	}
+}
+
+func (c *BigCache) onEvict(oldestEntry []byte, currentTimestamp uint64, evict func() error) {
+	oldestTimestamp := readTimestampFromEntry(oldestEntry)
+	if currentTimestamp-oldestTimestamp > c.lifeWindow {
+		evict()
+	}
+}
+
+func (s *cacheShard) removeOldestEntry() error {
+	oldest, err := s.entries.Pop()
+	if err == nil {
+		hash := readHashFromEntry(oldest)
+		delete(s.hashmap, hash)
+		return nil
+	}
+	return err
+}
+
+func (c *BigCache) getShard(hashedKey uint64) (shard *cacheShard) {
+	return c.shards[hashedKey&c.shardMask]
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func convertMBToBytes(value int) int {
+	return value * 1024 * 1024
+}

--- a/vendor/github.com/allegro/bigcache/bigcache_bench_test.go
+++ b/vendor/github.com/allegro/bigcache/bigcache_bench_test.go
@@ -1,0 +1,83 @@
+package bigcache
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"testing"
+	"time"
+)
+
+var message = blob('a', 256)
+
+func BenchmarkWriteToCacheWith1Shard(b *testing.B) {
+	writeToCache(b, 1, 100*time.Second, b.N)
+}
+
+func BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
+	m := blob('a', 1024)
+	cache, _ := NewBigCache(Config{1, 100 * time.Second, 100, 256, false, nil, 1})
+	for i := 0; i < b.N; i++ {
+		cache.Set(fmt.Sprintf("key-%d", i), m)
+	}
+}
+
+func BenchmarkWriteToUnlimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
+	m := blob('a', 1024)
+	cache, _ := NewBigCache(Config{1, 100 * time.Second, 100, 256, false, nil, 0})
+	for i := 0; i < b.N; i++ {
+		cache.Set(fmt.Sprintf("key-%d", i), m)
+	}
+}
+
+func BenchmarkWriteToCacheWith512Shards(b *testing.B) {
+	writeToCache(b, 512, 100*time.Second, b.N)
+}
+
+func BenchmarkWriteToCacheWith1024Shards(b *testing.B) {
+	writeToCache(b, 1024, 100*time.Second, b.N)
+}
+
+func BenchmarkWriteToCacheWith8192Shards(b *testing.B) {
+	writeToCache(b, 8192, 100*time.Second, b.N)
+}
+
+func BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize(b *testing.B) {
+	writeToCache(b, 1024, 100*time.Second, 100)
+}
+
+func BenchmarkReadFromCacheWith1024Shards(b *testing.B) {
+	readFromCache(b, 1024)
+}
+
+func BenchmarkReadFromCacheWith8192Shards(b *testing.B) {
+	readFromCache(b, 8192)
+}
+
+func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsInLifeWindow int) {
+	cache, _ := NewBigCache(Config{shards, lifeWindow, max(requestsInLifeWindow, 100), 500, false, nil, 0})
+	rand.Seed(time.Now().Unix())
+
+	b.RunParallel(func(pb *testing.PB) {
+		id := rand.Int()
+		counter := 0
+		for pb.Next() {
+			cache.Set(fmt.Sprintf("key-%d-%d", id, counter), message)
+			counter = counter + 1
+		}
+	})
+}
+
+func readFromCache(b *testing.B, shards int) {
+	cache, _ := NewBigCache(Config{8192, 1000 * time.Second, max(b.N, 100), 500, false, nil, 0})
+	for i := 0; i < b.N; i++ {
+		cache.Set(strconv.Itoa(i), message)
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			cache.Get(strconv.Itoa(rand.Intn(b.N)))
+		}
+	})
+}

--- a/vendor/github.com/allegro/bigcache/bigcache_test.go
+++ b/vendor/github.com/allegro/bigcache/bigcache_test.go
@@ -1,0 +1,176 @@
+package bigcache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteAndGetOnCache(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(DefaultConfig(5 * time.Second))
+	value := []byte("value")
+
+	// when
+	cache.Set("key", value)
+	cachedValue, err := cache.Get("key")
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, value, cachedValue)
+}
+
+func TestConstructCacheWithDefaultHasher(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, false, nil, 0})
+
+	assert.IsType(t, fnv64a{}, cache.hash)
+}
+
+func TestWillReturnErrorOnInvalidNumberOfPartitions(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, error := NewBigCache(Config{18, 5 * time.Second, 10, 256, false, nil, 0})
+
+	assert.Nil(t, cache)
+	assert.Error(t, error, "Shards number must be power of two")
+}
+
+func TestEntryNotFound(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, false, nil, 0})
+
+	// when
+	_, err := cache.Get("nonExistingKey")
+
+	// then
+	assert.EqualError(t, err, "Entry \"nonExistingKey\" not found")
+}
+
+func TestTimingEviction(t *testing.T) {
+	t.Parallel()
+
+	// given
+	clock := mockedClock{value: 0}
+	cache, _ := newBigCache(Config{1, time.Second, 1, 256, false, nil, 0}, &clock)
+
+	// when
+	cache.Set("key", []byte("value"))
+	clock.set(5)
+	cache.Set("key2", []byte("value2"))
+	_, err := cache.Get("key")
+
+	// then
+	assert.EqualError(t, err, "Entry \"key\" not found")
+}
+
+func TestEntryUpdate(t *testing.T) {
+	t.Parallel()
+
+	// given
+	clock := mockedClock{value: 0}
+	cache, _ := newBigCache(Config{1, 6 * time.Second, 1, 256, false, nil, 0}, &clock)
+
+	// when
+	cache.Set("key", []byte("value"))
+	clock.set(5)
+	cache.Set("key", []byte("value2"))
+	clock.set(7)
+	cache.Set("key2", []byte("value3"))
+	cachedValue, _ := cache.Get("key")
+
+	// then
+	assert.Equal(t, []byte("value2"), cachedValue)
+}
+
+func TestOldestEntryDeletionWhenMaxCacheSizeIsReached(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1})
+
+	// when
+	cache.Set("key1", blob('a', 1024*400))
+	cache.Set("key2", blob('b', 1024*400))
+	cache.Set("key3", blob('c', 1024*800))
+
+	_, key1Err := cache.Get("key1")
+	_, key2Err := cache.Get("key2")
+	entry3, _ := cache.Get("key3")
+
+	// then
+	assert.EqualError(t, key1Err, "Entry \"key1\" not found")
+	assert.EqualError(t, key2Err, "Entry \"key2\" not found")
+	assert.Equal(t, blob('c', 1024*800), entry3)
+}
+
+func TestEntryBiggerThanMaxShardSizeError(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1})
+
+	// when
+	err := cache.Set("key1", blob('a', 1024*1025))
+
+	// then
+	assert.EqualError(t, err, "Entry is bigger than max shard size.")
+}
+
+func TestHashCollision(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, true, hashStub(5), 0})
+
+	// when
+	cache.Set("liquid", []byte("value"))
+	cachedValue, err := cache.Get("liquid")
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("value"), cachedValue)
+
+	// when
+	cache.Set("costarring", []byte("value 2"))
+	cachedValue, err = cache.Get("costarring")
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("value 2"), cachedValue)
+
+	// when
+	cachedValue, err = cache.Get("liquid")
+
+	// then
+	assert.Error(t, err)
+	assert.Nil(t, cachedValue)
+}
+
+type mockedClock struct {
+	value int64
+}
+
+func (mc *mockedClock) epoch() int64 {
+	return mc.value
+}
+
+func (mc *mockedClock) set(value int64) {
+	mc.value = value
+}
+
+func blob(char byte, len int) []byte {
+	b := make([]byte, len)
+	for index := range b {
+		b[index] = char
+	}
+	return b
+}

--- a/vendor/github.com/allegro/bigcache/caches_bench/caches_bench_test.go
+++ b/vendor/github.com/allegro/bigcache/caches_bench/caches_bench_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/allegro/bigcache"
+	"github.com/coocood/freecache"
+)
+
+const maxEntrySize = 256
+
+func BenchmarkMapSet(b *testing.B) {
+	m := make(map[string][]byte)
+	for i := 0; i < b.N; i++ {
+		m[key(i)] = value()
+	}
+}
+
+func BenchmarkFreeCacheSet(b *testing.B) {
+	cache := freecache.NewCache(b.N * maxEntrySize)
+	for i := 0; i < b.N; i++ {
+		cache.Set([]byte(key(i)), value(), 0)
+	}
+}
+
+func BenchmarkBigCacheSet(b *testing.B) {
+	cache := initBigCache(b.N)
+	for i := 0; i < b.N; i++ {
+		cache.Set(key(i), value())
+	}
+}
+
+func BenchmarkMapGet(b *testing.B) {
+	b.StopTimer()
+	m := make(map[string][]byte)
+	for i := 0; i < b.N; i++ {
+		m[key(i)] = value()
+	}
+
+	b.StartTimer()
+	hitCount := 0
+	for i := 0; i < b.N; i++ {
+		if m[key(i)] != nil {
+			hitCount++
+		}
+	}
+}
+
+func BenchmarkFreeCacheGet(b *testing.B) {
+	b.StopTimer()
+	cache := freecache.NewCache(b.N * maxEntrySize)
+	for i := 0; i < b.N; i++ {
+		cache.Set([]byte(key(i)), value(), 0)
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Get([]byte(key(i)))
+	}
+}
+
+func BenchmarkBigCacheGet(b *testing.B) {
+	b.StopTimer()
+	cache := initBigCache(b.N)
+	for i := 0; i < b.N; i++ {
+		cache.Set(key(i), value())
+	}
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Get(key(i))
+	}
+}
+
+func BenchmarkBigCacheSetParallel(b *testing.B) {
+	cache := initBigCache(b.N)
+	rand.Seed(time.Now().Unix())
+
+	b.RunParallel(func(pb *testing.PB) {
+		id := rand.Intn(1000)
+		counter := 0
+		for pb.Next() {
+			cache.Set(parallelKey(id, counter), value())
+			counter = counter + 1
+		}
+	})
+}
+
+func BenchmarkFreeCacheSetParallel(b *testing.B) {
+	cache := freecache.NewCache(b.N * maxEntrySize)
+	rand.Seed(time.Now().Unix())
+
+	b.RunParallel(func(pb *testing.PB) {
+		id := rand.Intn(1000)
+		counter := 0
+		for pb.Next() {
+			cache.Set([]byte(parallelKey(id, counter)), value(), 0)
+			counter = counter + 1
+		}
+	})
+}
+
+func BenchmarkBigCacheGetParallel(b *testing.B) {
+	b.StopTimer()
+	cache := initBigCache(b.N)
+	for i := 0; i < b.N; i++ {
+		cache.Set(key(i), value())
+	}
+
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		counter := 0
+		for pb.Next() {
+			cache.Get(key(counter))
+			counter = counter + 1
+		}
+	})
+}
+
+func BenchmarkFreeCacheGetParallel(b *testing.B) {
+	b.StopTimer()
+	cache := freecache.NewCache(b.N * maxEntrySize)
+	for i := 0; i < b.N; i++ {
+		cache.Set([]byte(key(i)), value(), 0)
+	}
+
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		counter := 0
+		for pb.Next() {
+			cache.Get([]byte(key(counter)))
+			counter = counter + 1
+		}
+	})
+}
+
+func key(i int) string {
+	return fmt.Sprintf("key-%010d", i)
+}
+
+func value() []byte {
+	return make([]byte, 100)
+}
+
+func parallelKey(threadID int, counter int) string {
+	return fmt.Sprintf("key-%04d-%06d", threadID, counter)
+}
+
+func initBigCache(entriesInWindow int) *bigcache.BigCache {
+	cache, _ := bigcache.NewBigCache(bigcache.Config{
+		Shards:             256,
+		LifeWindow:         10 * time.Minute,
+		MaxEntriesInWindow: entriesInWindow,
+		MaxEntrySize:       maxEntrySize,
+		Verbose:            true,
+	})
+
+	return cache
+}

--- a/vendor/github.com/allegro/bigcache/caches_bench/caches_gc_overhead_comparsion.go
+++ b/vendor/github.com/allegro/bigcache/caches_bench/caches_gc_overhead_comparsion.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"time"
+
+	"github.com/allegro/bigcache"
+	"github.com/coocood/freecache"
+)
+
+func gcPause() time.Duration {
+	runtime.GC()
+	var stats debug.GCStats
+	debug.ReadGCStats(&stats)
+	return stats.Pause[0]
+}
+
+const (
+	entries   = 20000000
+	valueSize = 100
+)
+
+func main() {
+	debug.SetGCPercent(10)
+	fmt.Println("Number of entries: ", entries)
+
+	config := bigcache.Config{
+		Shards:             256,
+		LifeWindow:         100 * time.Minute,
+		MaxEntriesInWindow: entries,
+		MaxEntrySize:       200,
+		Verbose:            true,
+	}
+
+	bigcache, _ := bigcache.NewBigCache(config)
+	for i := 0; i < entries; i++ {
+		key, val := generateKeyValue(i, valueSize)
+		bigcache.Set(key, val)
+	}
+
+	firstKey, _ := generateKeyValue(1, valueSize)
+	checkFirstElement(bigcache.Get(firstKey))
+
+	fmt.Println("GC pause for bigcache: ", gcPause())
+	bigcache = nil
+	gcPause()
+
+	//------------------------------------------
+
+	freeCache := freecache.NewCache(entries * 200) //allocate entries * 200 bytes
+	for i := 0; i < entries; i++ {
+		key, val := generateKeyValue(i, valueSize)
+		if err := freeCache.Set([]byte(key), val, 0); err != nil {
+			fmt.Println("Error in set: ", err.Error())
+		}
+	}
+
+	firstKey, _ = generateKeyValue(1, valueSize)
+	checkFirstElement(freeCache.Get([]byte(firstKey)))
+
+	if freeCache.OverwriteCount() != 0 {
+		fmt.Println("Overwritten: ", freeCache.OverwriteCount())
+	}
+	fmt.Println("GC pause for freecache: ", gcPause())
+	freeCache = nil
+	gcPause()
+
+	//------------------------------------------
+
+	mapCache := make(map[string][]byte)
+	for i := 0; i < entries; i++ {
+		key, val := generateKeyValue(i, valueSize)
+		mapCache[key] = val
+	}
+	fmt.Println("GC pause for map: ", gcPause())
+
+}
+
+func checkFirstElement(val []byte, err error) {
+	_, expectedVal := generateKeyValue(1, valueSize)
+	if err != nil {
+		fmt.Println("Error in get: ", err.Error())
+	} else if string(val) != string(expectedVal) {
+		fmt.Println("Wrong first element: ", string(val))
+	}
+}
+
+func generateKeyValue(index int, valSize int) (string, []byte) {
+	key := fmt.Sprintf("key-%010d", index)
+	fixedNumber := []byte(fmt.Sprintf("%010d", index))
+	val := append(make([]byte, valSize-10), fixedNumber...)
+
+	return key, val
+}

--- a/vendor/github.com/allegro/bigcache/clock.go
+++ b/vendor/github.com/allegro/bigcache/clock.go
@@ -1,0 +1,14 @@
+package bigcache
+
+import "time"
+
+type clock interface {
+	epoch() int64
+}
+
+type systemClock struct {
+}
+
+func (c systemClock) epoch() int64 {
+	return time.Now().Unix()
+}

--- a/vendor/github.com/allegro/bigcache/config.go
+++ b/vendor/github.com/allegro/bigcache/config.go
@@ -1,0 +1,39 @@
+package bigcache
+
+import "time"
+
+// Config for BigCache
+type Config struct {
+	// Number of cache shards, value must be a power of two
+	Shards int
+	// Time after which entry can be evicted
+	LifeWindow time.Duration
+	// Max number of entries in life window. Used only to calculate initial size for cache shards.
+	// When proper value is set then additional memory allocation does not occur.
+	MaxEntriesInWindow int
+	// Max size of entry in bytes. Used only to calculate initial size for cache shards.
+	MaxEntrySize int
+	// Verbose mode prints information about new memory allocation
+	Verbose bool
+	// Hasher used to map between string keys and unsigned 64bit integers, by default fnv64 hashing is used.
+	Hasher Hasher
+	// HardMaxCacheSize is a limit for cache size in MB. Cache will not allocate more memory than this limit.
+	// It can protect application from consuming all available memory on machine, therefore from running OOM Killer.
+	// Default value is 0 which means unlimited size. When the limit is higher than 0 and reached then
+	// the oldest entries are overridden for the new ones.
+	HardMaxCacheSize int
+}
+
+// DefaultConfig initializes config with default values.
+// When load for BigCache can be predicted in advance then it is better to use custom config.
+func DefaultConfig(eviction time.Duration) Config {
+	return Config{
+		Shards:             1024,
+		LifeWindow:         eviction,
+		MaxEntriesInWindow: 1000 * 10 * 60,
+		MaxEntrySize:       500,
+		Verbose:            true,
+		Hasher:             newDefaultHasher(),
+		HardMaxCacheSize:   0,
+	}
+}

--- a/vendor/github.com/allegro/bigcache/encoding.go
+++ b/vendor/github.com/allegro/bigcache/encoding.go
@@ -1,0 +1,52 @@
+package bigcache
+
+import (
+	"encoding/binary"
+)
+
+const (
+	timestampSizeInBytes = 8                                                       // Number of bytes used for timestamp
+	hashSizeInBytes      = 8                                                       // Number of bytes used for hash
+	keySizeInBytes       = 2                                                       // Number of bytes used for size of entry key
+	headersSizeInBytes   = timestampSizeInBytes + hashSizeInBytes + keySizeInBytes // Number of bytes used for all headers
+)
+
+func wrapEntry(timestamp uint64, hash uint64, key string, entry []byte, buffer *[]byte) []byte {
+	keyLength := len(key)
+	blobLength := len(entry) + headersSizeInBytes + keyLength
+
+	if blobLength > len(*buffer) {
+		*buffer = make([]byte, blobLength)
+	}
+	blob := *buffer
+
+	binary.LittleEndian.PutUint64(blob, timestamp)
+	binary.LittleEndian.PutUint64(blob[timestampSizeInBytes:], hash)
+	binary.LittleEndian.PutUint16(blob[timestampSizeInBytes+hashSizeInBytes:], uint16(keyLength))
+	copy(blob[headersSizeInBytes:], []byte(key))
+	copy(blob[headersSizeInBytes+keyLength:], entry)
+
+	return blob[:blobLength]
+}
+
+func readEntry(data []byte) []byte {
+	length := binary.LittleEndian.Uint16(data[timestampSizeInBytes+hashSizeInBytes:])
+	return data[headersSizeInBytes+length:]
+}
+
+func readTimestampFromEntry(data []byte) uint64 {
+	return binary.LittleEndian.Uint64(data)
+}
+
+func readKeyFromEntry(data []byte) string {
+	length := binary.LittleEndian.Uint16(data[timestampSizeInBytes+hashSizeInBytes:])
+	return string(data[headersSizeInBytes : headersSizeInBytes+length])
+}
+
+func readHashFromEntry(data []byte) uint64 {
+	return binary.LittleEndian.Uint64(data[timestampSizeInBytes:])
+}
+
+func resetKeyFromEntry(data []byte) {
+	binary.LittleEndian.PutUint64(data[timestampSizeInBytes:], 0)
+}

--- a/vendor/github.com/allegro/bigcache/encoding_test.go
+++ b/vendor/github.com/allegro/bigcache/encoding_test.go
@@ -1,0 +1,46 @@
+package bigcache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	// given
+	now := uint64(time.Now().Unix())
+	hash := uint64(42)
+	key := "key"
+	data := []byte("data")
+	buffer := make([]byte, 100)
+
+	// when
+	wrapped := wrapEntry(now, hash, key, data, &buffer)
+
+	// then
+	assert.Equal(t, key, readKeyFromEntry(wrapped))
+	assert.Equal(t, hash, readHashFromEntry(wrapped))
+	assert.Equal(t, now, readTimestampFromEntry(wrapped))
+	assert.Equal(t, data, readEntry(wrapped))
+	assert.Equal(t, 100, len(buffer))
+}
+
+func TestAllocateBiggerBuffer(t *testing.T) {
+	//given
+	now := uint64(time.Now().Unix())
+	hash := uint64(42)
+	key := "1"
+	data := []byte("2")
+	buffer := make([]byte, 1)
+
+	// when
+	wrapped := wrapEntry(now, hash, key, data, &buffer)
+
+	// then
+	assert.Equal(t, key, readKeyFromEntry(wrapped))
+	assert.Equal(t, hash, readHashFromEntry(wrapped))
+	assert.Equal(t, now, readTimestampFromEntry(wrapped))
+	assert.Equal(t, data, readEntry(wrapped))
+	assert.Equal(t, 2+headersSizeInBytes, len(buffer))
+}

--- a/vendor/github.com/allegro/bigcache/entry_not_found_error.go
+++ b/vendor/github.com/allegro/bigcache/entry_not_found_error.go
@@ -1,0 +1,17 @@
+package bigcache
+
+import "fmt"
+
+// EntryNotFoundError is an error type struct which is returned when entry was not found for provided key
+type EntryNotFoundError struct {
+	message string
+}
+
+func notFound(key string) error {
+	return &EntryNotFoundError{fmt.Sprintf("Entry %q not found", key)}
+}
+
+// Error returned when entry does not exist.
+func (e EntryNotFoundError) Error() string {
+	return e.message
+}

--- a/vendor/github.com/allegro/bigcache/hash.go
+++ b/vendor/github.com/allegro/bigcache/hash.go
@@ -1,0 +1,25 @@
+package bigcache
+
+import (
+	"hash/fnv"
+)
+
+// Hasher is responsible for generating unsigned, 64 bit hash of provided string. Hasher should minimize collisions
+// (generating same hash for different strings) and while performance is also important fast functions are preferable (i.e.
+// you can use FarmHash family).
+type Hasher interface {
+	Sum64(string) uint64
+}
+
+func newDefaultHasher() Hasher {
+	return fnv64a{}
+}
+
+type fnv64a struct {
+}
+
+func (f fnv64a) Sum64(key string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(key))
+	return h.Sum64()
+}

--- a/vendor/github.com/allegro/bigcache/hash_test.go
+++ b/vendor/github.com/allegro/bigcache/hash_test.go
@@ -1,0 +1,7 @@
+package bigcache
+
+type hashStub uint64
+
+func (stub hashStub) Sum64(_ string) uint64 {
+	return uint64(stub)
+}

--- a/vendor/github.com/allegro/bigcache/queue/bytes_queue.go
+++ b/vendor/github.com/allegro/bigcache/queue/bytes_queue.go
@@ -1,0 +1,199 @@
+package queue
+
+import (
+	"encoding/binary"
+	"log"
+	"time"
+)
+
+const (
+	// Number of bytes used to keep information about entry size
+	headerEntrySize = 4
+	// Bytes before left margin are not used. Zero index means element does not exist in queue, useful while reading slice from index
+	leftMarginIndex = 1
+	// Minimum empty blob size in bytes. Empty blob fills space between tail and head in additional memory allocation.
+	// It keeps entries indexes unchanged
+	minimumEmptyBlobSize = 32 + headerEntrySize
+)
+
+// BytesQueue is a non-thread safe queue type of fifo based on bytes array.
+// For every push operation index of entry is returned. It can be used to read the entry later
+type BytesQueue struct {
+	array        []byte
+	capacity     int
+	maxCapacity  int
+	head         int
+	tail         int
+	count        int
+	rightMargin  int
+	headerBuffer []byte
+	verbose      bool
+}
+
+type queueError struct {
+	message string
+}
+
+// NewBytesQueue initialize new bytes queue.
+// Initial capacity is used in bytes array allocation
+// When verbose flag is set then information about memory allocation are printed
+func NewBytesQueue(initialCapacity int, maxCapacity int, verbose bool) *BytesQueue {
+	return &BytesQueue{
+		array:        make([]byte, initialCapacity),
+		capacity:     initialCapacity,
+		maxCapacity:  maxCapacity,
+		headerBuffer: make([]byte, headerEntrySize),
+		tail:         leftMarginIndex,
+		head:         leftMarginIndex,
+		rightMargin:  leftMarginIndex,
+		verbose:      verbose,
+	}
+}
+
+// Push copies entry at the end of queue and moves tail pointer. Allocates more space if needed.
+// Returns index for pushed data or error if maximum size queue limit is reached.
+func (q *BytesQueue) Push(data []byte) (int, error) {
+	dataLen := len(data)
+
+	if q.availableSpaceAfterTail() < dataLen+headerEntrySize {
+		if q.availableSpaceBeforeHead() >= dataLen+headerEntrySize {
+			q.tail = leftMarginIndex
+		} else if q.capacity+headerEntrySize+dataLen >= q.maxCapacity && q.maxCapacity > 0 {
+			return -1, &queueError{"Full queue. Maximum size limit reached."}
+		} else {
+			q.allocateAdditionalMemory(dataLen + headerEntrySize)
+		}
+	}
+
+	index := q.tail
+
+	q.push(data, dataLen)
+
+	return index, nil
+}
+
+func (q *BytesQueue) allocateAdditionalMemory(minimum int) {
+	start := time.Now()
+	if q.capacity < minimum {
+		q.capacity += minimum
+	}
+	q.capacity = q.capacity * 2
+	if q.capacity > q.maxCapacity && q.maxCapacity > 0 {
+		q.capacity = q.maxCapacity
+	}
+
+	oldArray := q.array
+	q.array = make([]byte, q.capacity)
+
+	if leftMarginIndex != q.rightMargin {
+		copy(q.array, oldArray[:q.rightMargin])
+
+		if q.tail < q.head {
+			emptyBlobLen := q.head - q.tail - headerEntrySize
+			q.push(make([]byte, emptyBlobLen), emptyBlobLen)
+			q.head = leftMarginIndex
+			q.tail = q.rightMargin
+		}
+	}
+
+	if q.verbose {
+		log.Printf("Allocated new queue in %s; Capacity: %d \n", time.Since(start), q.capacity)
+	}
+}
+
+func (q *BytesQueue) push(data []byte, len int) {
+	binary.LittleEndian.PutUint32(q.headerBuffer, uint32(len))
+	q.copy(q.headerBuffer, headerEntrySize)
+
+	q.copy(data, len)
+
+	if q.tail > q.head {
+		q.rightMargin = q.tail
+	}
+
+	q.count++
+}
+
+func (q *BytesQueue) copy(data []byte, len int) {
+	q.tail += copy(q.array[q.tail:], data[:len])
+}
+
+// Pop reads the oldest entry from queue and moves head pointer to the next one
+func (q *BytesQueue) Pop() ([]byte, error) {
+	data, size, err := q.peek(q.head)
+	if err != nil {
+		return nil, err
+	}
+
+	q.head += headerEntrySize + size
+	q.count--
+
+	if q.head == q.rightMargin {
+		q.head = leftMarginIndex
+		if q.tail == q.rightMargin {
+			q.tail = leftMarginIndex
+		}
+		q.rightMargin = q.tail
+	}
+
+	return data, nil
+}
+
+// Peek reads the oldest entry from list without moving head pointer
+func (q *BytesQueue) Peek() ([]byte, error) {
+	data, _, err := q.peek(q.head)
+	return data, err
+}
+
+// Get reads entry from index
+func (q *BytesQueue) Get(index int) ([]byte, error) {
+	data, _, err := q.peek(index)
+	return data, err
+}
+
+// Capacity returns number of allocated bytes for queue
+func (q *BytesQueue) Capacity() int {
+	return q.capacity
+}
+
+// Len returns number of entries kept in queue
+func (q *BytesQueue) Len() int {
+	return q.count
+}
+
+// Error returns error message
+func (e *queueError) Error() string {
+	return e.message
+}
+
+func (q *BytesQueue) peek(index int) ([]byte, int, error) {
+
+	if q.count == 0 {
+		return nil, 0, &queueError{"Empty queue"}
+	}
+
+	if index <= 0 {
+		return nil, 0, &queueError{"Index must be grater than zero. Invalid index."}
+	}
+
+	if index+headerEntrySize >= len(q.array) {
+		return nil, 0, &queueError{"Index out of range"}
+	}
+
+	blockSize := int(binary.LittleEndian.Uint32(q.array[index : index+headerEntrySize]))
+	return q.array[index+headerEntrySize : index+headerEntrySize+blockSize], blockSize, nil
+}
+
+func (q *BytesQueue) availableSpaceAfterTail() int {
+	if q.tail >= q.head {
+		return q.capacity - q.tail
+	}
+	return q.head - q.tail - minimumEmptyBlobSize
+}
+
+func (q *BytesQueue) availableSpaceBeforeHead() int {
+	if q.tail >= q.head {
+		return q.head - leftMarginIndex - minimumEmptyBlobSize
+	}
+	return q.head - q.tail - minimumEmptyBlobSize
+}

--- a/vendor/github.com/allegro/bigcache/queue/bytes_queue_test.go
+++ b/vendor/github.com/allegro/bigcache/queue/bytes_queue_test.go
@@ -1,0 +1,329 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPushAndPop(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(10, 0, true)
+	entry := []byte("hello")
+
+	// when
+	_, err := queue.Pop()
+
+	// then
+	assert.EqualError(t, err, "Empty queue")
+
+	// when
+	queue.Push(entry)
+
+	// then
+	assert.Equal(t, entry, pop(queue))
+}
+
+func TestLen(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(100, 0, false)
+	entry := []byte("hello")
+	assert.Zero(t, queue.Len())
+
+	// when
+	queue.Push(entry)
+
+	// then
+	assert.Equal(t, queue.Len(), 1)
+}
+
+func TestPeek(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(100, 0, false)
+	entry := []byte("hello")
+
+	// when
+	read, err := queue.Peek()
+
+	// then
+	assert.EqualError(t, err, "Empty queue")
+	assert.Nil(t, read)
+
+	// when
+	queue.Push(entry)
+	read, err = queue.Peek()
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, pop(queue), read)
+	assert.Equal(t, entry, read)
+}
+
+func TestReuseAvailableSpace(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(100, 0, false)
+
+	// when
+	queue.Push(blob('a', 70))
+	queue.Push(blob('b', 20))
+	queue.Pop()
+	queue.Push(blob('c', 20))
+
+	// then
+	assert.Equal(t, 100, queue.Capacity())
+	assert.Equal(t, blob('b', 20), pop(queue))
+}
+
+func TestAllocateAdditionalSpace(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(11, 0, false)
+
+	// when
+	queue.Push([]byte("hello1"))
+	queue.Push([]byte("hello2"))
+
+	// then
+	assert.Equal(t, 22, queue.Capacity())
+}
+
+func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereHeadIsBeforeTail(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(25, 0, false)
+
+	// when
+	queue.Push(blob('a', 3)) // header + entry + left margin = 8 bytes
+	queue.Push(blob('b', 6)) // additional 10 bytes
+	queue.Pop()              // space freed, 7 bytes available at the beginning
+	queue.Push(blob('c', 6)) // 10 bytes needed, 14 available but not in one segment, allocate additional memory
+
+	// then
+	assert.Equal(t, 50, queue.Capacity())
+	assert.Equal(t, blob('b', 6), pop(queue))
+	assert.Equal(t, blob('c', 6), pop(queue))
+}
+
+func TestUnchangedEntriesIndexesAfterAdditionalMemoryAllocationWhereHeadIsBeforeTail(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(25, 0, false)
+
+	// when
+	queue.Push(blob('a', 3))                   // header + entry + left margin = 8 bytes
+	index, _ := queue.Push(blob('b', 6))       // additional 10 bytes
+	queue.Pop()                                // space freed, 7 bytes available at the beginning
+	newestIndex, _ := queue.Push(blob('c', 6)) // 10 bytes needed, 14 available but not in one segment, allocate additional memory
+
+	// then
+	assert.Equal(t, 50, queue.Capacity())
+	assert.Equal(t, blob('b', 6), get(queue, index))
+	assert.Equal(t, blob('c', 6), get(queue, newestIndex))
+}
+
+func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereTailIsBeforeHead(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(100, 0, false)
+
+	// when
+	queue.Push(blob('a', 70)) // header + entry + left margin = 75 bytes
+	queue.Push(blob('b', 10)) // 75 + 10 + 4 = 89 bytes
+	queue.Pop()               // space freed at the beginning
+	queue.Push(blob('c', 30)) // 34 bytes used at the beginning, tail pointer is before head pointer
+	queue.Push(blob('d', 40)) // 44 bytes needed but no available in one segment, allocate new memory
+
+	// then
+	assert.Equal(t, 200, queue.Capacity())
+	assert.Equal(t, blob('c', 30), pop(queue))
+	// empty blob fills space between tail and head,
+	// created when additional memory was allocated,
+	// it keeps current entries indexes unchanged
+	assert.Equal(t, blob(0, 36), pop(queue))
+	assert.Equal(t, blob('b', 10), pop(queue))
+	assert.Equal(t, blob('d', 40), pop(queue))
+}
+
+func TestUnchangedEntriesIndexesAfterAdditionalMemoryAllocationWhereTailIsBeforeHead(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(100, 0, false)
+
+	// when
+	queue.Push(blob('a', 70))                   // header + entry + left margin = 75 bytes
+	index, _ := queue.Push(blob('b', 10))       // 75 + 10 + 4 = 89 bytes
+	queue.Pop()                                 // space freed at the beginning
+	queue.Push(blob('c', 30))                   // 34 bytes used at the beginning, tail pointer is before head pointer
+	newestIndex, _ := queue.Push(blob('d', 40)) // 44 bytes needed but no available in one segment, allocate new memory
+
+	// then
+	assert.Equal(t, 200, queue.Capacity())
+	assert.Equal(t, blob('b', 10), get(queue, index))
+	assert.Equal(t, blob('d', 40), get(queue, newestIndex))
+}
+
+func TestAllocateAdditionalSpaceForValueBiggerThanInitQueue(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(11, 0, false)
+
+	// when
+	queue.Push(blob('a', 100))
+
+	// then
+	assert.Equal(t, blob('a', 100), pop(queue))
+	assert.Equal(t, 230, queue.Capacity())
+}
+
+func TestAllocateAdditionalSpaceForValueBiggerThanQueue(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(21, 0, false)
+
+	// when
+	queue.Push(make([]byte, 2))
+	queue.Push(make([]byte, 2))
+	queue.Push(make([]byte, 100))
+
+	// then
+	queue.Pop()
+	queue.Pop()
+	assert.Equal(t, make([]byte, 100), pop(queue))
+	assert.Equal(t, 250, queue.Capacity())
+}
+
+func TestPopWholeQueue(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(13, 0, false)
+
+	// when
+	queue.Push([]byte("a"))
+	queue.Push([]byte("b"))
+	queue.Pop()
+	queue.Pop()
+	queue.Push([]byte("c"))
+
+	// then
+	assert.Equal(t, 13, queue.Capacity())
+	assert.Equal(t, []byte("c"), pop(queue))
+}
+
+func TestGetEntryFromIndex(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(20, 0, false)
+
+	// when
+	queue.Push([]byte("a"))
+	index, _ := queue.Push([]byte("b"))
+	queue.Push([]byte("c"))
+	result, _ := queue.Get(index)
+
+	// then
+	assert.Equal(t, []byte("b"), result)
+}
+
+func TestGetEntryFromInvalidIndex(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(1, 0, false)
+	queue.Push([]byte("a"))
+
+	// when
+	result, err := queue.Get(0)
+
+	// then
+	assert.Nil(t, result)
+	assert.EqualError(t, err, "Index must be grater than zero. Invalid index.")
+}
+
+func TestGetEntryFromIndexOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(1, 0, false)
+	queue.Push([]byte("a"))
+
+	// when
+	result, err := queue.Get(42)
+
+	// then
+	assert.Nil(t, result)
+	assert.EqualError(t, err, "Index out of range")
+}
+
+func TestGetEntryFromEmptyQueue(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(13, 0, false)
+
+	// when
+	result, err := queue.Get(1)
+
+	// then
+	assert.Nil(t, result)
+	assert.EqualError(t, err, "Empty queue")
+}
+
+func TestMaxSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(30, 50, false)
+
+	// when
+	queue.Push(blob('a', 25))
+	queue.Push(blob('b', 5))
+	capacity := queue.Capacity()
+	_, err := queue.Push(blob('c', 15))
+
+	// then
+	assert.Equal(t, 50, capacity)
+	assert.EqualError(t, err, "Full queue. Maximum size limit reached.")
+	assert.Equal(t, blob('a', 25), pop(queue))
+	assert.Equal(t, blob('b', 5), pop(queue))
+}
+
+func pop(queue *BytesQueue) []byte {
+	entry, err := queue.Pop()
+	if err != nil {
+		panic(err)
+	}
+	return entry
+}
+
+func get(queue *BytesQueue, index int) []byte {
+	entry, err := queue.Get(index)
+	if err != nil {
+		panic(err)
+	}
+	return entry
+}
+
+func blob(char byte, len int) []byte {
+	b := make([]byte, len)
+	for index := range b {
+		b[index] = char
+	}
+	return b
+}


### PR DESCRIPTION
- completely rewrote caching system
- laid groundwork and code for encoding/binary and in process caching
- user cache will be limited to a fixed size, default 32MB
- bigcache will automatically expire records that are tool old
- fixes #61
