### PR TITLE
Fixes #67 Serialize access for a user so X-L-M is always unique

### DIFF
--- a/api/context_cache_test.go
+++ b/api/context_cache_test.go
@@ -63,7 +63,17 @@ func TestCollectionCacheModified(t *testing.T) {
 	assert.Equal(11, c.GetModified(uid))
 	c.Clear(uid)
 	assert.Equal(0, c.GetModified(uid))
+}
 
+func TestCollectionCacheTouch(t *testing.T) {
+	assert := assert.New(t)
+	c := NewCollectionCache()
+	uid := "10"
+
+	assert.Equal(time.Duration(0), c.Touch(uid))
+	time.Sleep(2 * time.Millisecond)
+	diff := c.Touch(uid)
+	assert.NotEqual(time.Duration(0), diff)
 }
 
 func TestCollectionCacheInfoCollections(t *testing.T) {
@@ -164,6 +174,14 @@ func BenchmarkCacheKey(b *testing.B) {
 		cacheKey("A", "BCDEFGHIJK")
 	}
 }
+
+func BenchmarkCacheTouch(b *testing.B) {
+	cache := NewCollectionCache()
+	for i := 0; i < b.N; i++ {
+		cache.Touch("1")
+	}
+}
+
 func BenchmarkCollectionCacheClear(b *testing.B) {
 	cache := NewCollectionCache()
 	for i := 0; i < b.N; i++ {

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -608,13 +608,14 @@ func (d *DB) DeleteBSOs(cId int, bIds ...string) (modified int, err error) {
 		return
 	}
 
-	dml := "DELETE FROM BSO WHERE Id IN (?" +
+	dml := "DELETE FROM BSO WHERE CollectionId=? AND Id IN (?" +
 		strings.Repeat(",?", len(bIds)-1) + ")"
 
 	// https://golang.org/doc/faq#convert_slice_of_interface
-	ids := make([]interface{}, len(bIds))
+	ids := make([]interface{}, len(bIds)+1)
+	ids[0] = cId
 	for i, v := range bIds {
-		ids[i] = v
+		ids[i+1] = v
 	}
 
 	_, err = tx.Exec(dml, ids...)

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -461,6 +461,29 @@ func TestPrivateGetBSOsSort(t *testing.T) {
 	}
 }
 
+// Regression test for bug that deleted BSOs in *all* collections
+func TestDeleteBSOsInCorrectCollection(t *testing.T) {
+	db, _ := getTestDB()
+	assert := assert.New(t)
+
+	payload := "data"
+	if _, err := db.PutBSO(1, "b1", &payload, nil, nil); !assert.NoError(err) {
+		return
+	}
+	if _, err := db.PutBSO(2, "b1", &payload, nil, nil); !assert.NoError(err) {
+		return
+	}
+
+	_, err := db.DeleteBSOs(1, "b1")
+	if !assert.NoError(err) {
+		return
+	}
+
+	bso, err := db.GetBSO(2, "b1")
+	assert.NotNil(bso)
+	assert.NoError(err)
+}
+
 func TestLastModified(t *testing.T) {
 	t.Parallel()
 	db, _ := getTestDB()

--- a/syncstorage/dispatch.go
+++ b/syncstorage/dispatch.go
@@ -59,10 +59,13 @@ func (d *Dispatch) Shutdown() {
 	}
 }
 
+// LockUser locks a user to prevent parallel API calls
 func (d *Dispatch) LockUser(uid string) error {
 	return d.pools[d.Index(uid)].Use(uid)
 
 }
+
+// UnlockUser release the lock on the user so waiting API calls can continue
 func (d *Dispatch) UnlockUser(uid string) error {
 	return d.pools[d.Index(uid)].Release(uid)
 }


### PR DESCRIPTION
This change ensures that X-Last-Modified is monotonically increases
whenever there is a change (POST, PUT, DELETE) to the user's data. This
is accomplished simply by delaying a request by 10ms if the data was
changed < 10ms ago.

Also a _very_ huge bug was found while adding this feature. The previous
db.DeleteBSOs() function did not include the collection Id so it would
delete all BSOs with the same Id regardless of the collection it was in.
