### PR TITLE
Fixes #70 Purge expired BSOs and recover disk space

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -67,6 +67,7 @@ func NewRouterFromContext(c *Context) http.Handler {
 	r.HandleFunc("/__lbheartbeat__", handleHeartbeat)
 	r.HandleFunc("/__version__", handleVersion)
 
+	// top level deletions for the user and their storage
 	r.HandleFunc("/1.5/{uid:[0-9]+}", hs(c.hDeleteEverything)).Methods("DELETE")
 	r.HandleFunc("/1.5/{uid:[0-9]+}/storage", hs(c.hDeleteEverything)).Methods("DELETE")
 
@@ -81,7 +82,6 @@ func NewRouterFromContext(c *Context) http.Handler {
 	info.HandleFunc("/quota", hs(c.hInfoQuota)).Methods("GET")
 
 	storage := v.PathPrefix("/storage/").Subrouter()
-	storage.HandleFunc("/", handleTODO).Methods("DELETE")
 
 	storage.HandleFunc("/{collection}", ahs(c.hCollectionGET)).Methods("GET")
 	storage.HandleFunc("/{collection}", hs(c.hCollectionPOST)).Methods("POST")

--- a/api/context_test.go
+++ b/api/context_test.go
@@ -1433,7 +1433,6 @@ func TestContextBsoDELETE(t *testing.T) {
 func TestContextDelete(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
-	context := makeTestContext()
 	uid := "123456"
 
 	var (
@@ -1441,7 +1440,9 @@ func TestContextDelete(t *testing.T) {
 		err error
 	)
 
+	// test both DELETE /1.5/<uid> and /1.5/<uid>/storage
 	for _, url := range []string{"/1.5/" + uid, "/1.5/" + uid + "/storage"} {
+		context := makeTestContext()
 		if cId, err = context.Dispatch.CreateCollection(uid, "my_collection"); !assert.NoError(err) {
 			return
 		}
@@ -1463,8 +1464,8 @@ func TestContextDelete(t *testing.T) {
 		assert.Nil(b)
 
 		cTest, err := context.Dispatch.GetCollectionId(uid, "my_collection")
-		assert.Exactly(syncstorage.ErrNotFound, err)
-		assert.Equal(0, cTest)
+		assert.Nil(err)
+		assert.Equal(100, cTest)
 	}
 
 }

--- a/api/loghandler.go
+++ b/api/loghandler.go
@@ -136,6 +136,7 @@ func (f *MozlogFormatter) Format(entry *log.Entry) ([]byte, error) {
 		}
 	}
 
+	entry.Data["msg"] = entry.Message
 	m := &mozlog{
 		Timestamp:  entry.Time.UnixNano(),
 		Type:       logType,

--- a/config/config.go
+++ b/config/config.go
@@ -25,19 +25,20 @@ var Config struct {
 	Port     int
 	Secrets  []string
 	DataDir  string
+	TTL      int `envconfig:"default=300"`
 
 	MaxOpenFiles int `envconfig:"default=64"`
 }
 
 // so we can use config.Port and not config.Config.Port
 var (
-	Hostname     string
-	Log          *LogConfig
-	Host         string
-	Port         int
-	DataDir      string
-	Secrets      []string
-	MaxOpenFiles int
+	Hostname string
+	Log      *LogConfig
+	Host     string
+	Port     int
+	DataDir  string
+	Secrets  []string
+	TTL      int
 )
 
 func init() {
@@ -47,10 +48,6 @@ func init() {
 
 	if Config.Port < 1 || Config.Port > 65535 {
 		log.Fatal("Config.Error: PORT invalid")
-	}
-
-	if Config.MaxOpenFiles%8 != 0 || Config.MaxOpenFiles < 8 {
-		log.Fatal("Config Error: MAX_OPEN_FILES must be >= 8 and MAX_OPEN_FILES mod 8 == 0")
 	}
 
 	if _, err := os.Stat(Config.DataDir); os.IsNotExist(err) {
@@ -85,11 +82,15 @@ func init() {
 		Config.Hostname, _ = os.Hostname()
 	}
 
+	if Config.TTL <= 0 {
+		log.Fatal("TTL must be > 0")
+	}
+
 	Hostname = Config.Hostname
 	Log = Config.Log
 	Host = Config.Host
 	Port = Config.Port
 	Secrets = Config.Secrets
 	DataDir = Config.DataDir
-	MaxOpenFiles = Config.MaxOpenFiles
+	TTL = Config.TTL
 }

--- a/server.go
+++ b/server.go
@@ -32,7 +32,7 @@ func init() {
 func main() {
 	numPools := uint16(8)
 	dispatch, err := syncstorage.NewDispatch(
-		numPools, config.DataDir, 5*time.Minute)
+		numPools, config.DataDir, time.Duration(config.TTL)*time.Second)
 
 	if err != nil {
 		log.Fatal(err)
@@ -76,6 +76,7 @@ func main() {
 	log.WithFields(log.Fields{
 		"addr": listenOn,
 		"PID":  os.Getpid(),
+		"TTL":  config.TTL,
 	}).Info("HTTP Listening at " + listenOn)
 
 	err = httpdown.ListenAndServe(server, hd)

--- a/syncstorage/dispatch.go
+++ b/syncstorage/dispatch.go
@@ -54,8 +54,7 @@ func (d *Dispatch) Shutdown() {
 	numPools := len(d.pools)
 	for k, p := range d.pools {
 		log.Info(fmt.Sprintf("Shutting down Pool %d/%d", k+1, numPools))
-		p.Stop()
-		p.CloseOpenConnections()
+		p.Shutdown()
 	}
 }
 

--- a/syncstorage/dispatchwrap_test.go
+++ b/syncstorage/dispatchwrap_test.go
@@ -1,13 +1,17 @@
 package syncstorage
 
-import "time"
+import (
+	"strconv"
+	"time"
+)
 
 func newDispatchwrap() *dispatchwrap {
-	return newDispatchwrapUID("1234567890")
+	uid := strconv.FormatInt(time.Now().UnixNano(), 36)
+	return newDispatchwrapUID(uid)
 }
 func newDispatchwrapUID(uid string) *dispatchwrap {
 
-	d, err := NewDispatch(4, getTempBase(), time.Millisecond*10)
+	d, err := NewDispatch(4, getTempBase(), time.Minute)
 	if err != nil {
 		panic(err)
 	}

--- a/syncstorage/pool_dbelement.go
+++ b/syncstorage/pool_dbelement.go
@@ -1,0 +1,103 @@
+package syncstorage
+
+import (
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+)
+
+// dbelement is used by pool to keep track of in use and open db
+type dbelement struct {
+	sync.Mutex
+
+	uid   string
+	inUse bool
+
+	// track if expired BSOs have been purged
+	purgeRan bool
+
+	db *DB
+
+	// last time this was used
+	lastUsed time.Time
+}
+
+func (de *dbelement) BeenPurged() bool {
+	de.Use()
+	defer de.Release()
+
+	return de.purgeRan
+}
+
+// Use locks the dbelement so multiple calls to the database
+// can be done. This is used to synchronize access for HTTP api call
+// handlers which can make mulitple read/write requests in a discrete
+// request
+func (de *dbelement) Use() {
+	de.Lock()
+	de.inUse = true
+}
+func (de *dbelement) Release() {
+	de.inUse = false
+	de.Unlock()
+}
+
+func (de *dbelement) InUse() bool {
+	return de.inUse
+}
+
+// purgeElement will purge expired rows and log how much recoverable
+// space is in a database
+type purgeResults struct {
+	uid       string
+	numPurged int
+
+	took               time.Duration
+	total, free, bytes int // page stats
+}
+
+// Fields creates a log.Fields
+func (r *purgeResults) Fields() log.Fields {
+	return log.Fields{
+		"uid":          r.uid,
+		"purged":       r.numPurged,
+		"pages_total":  r.total,
+		"pages_free":   r.free,
+		"unused_bytes": r.bytes,
+		"t":            int64(r.took / time.Millisecond),
+	}
+}
+
+// purge removes all expired BSOs from the user's DB
+func (de *dbelement) purge() (*purgeResults, error) {
+	de.Use()
+	defer de.Release()
+
+	if de.purgeRan {
+		return nil, nil
+	} else {
+		de.purgeRan = true
+	}
+
+	start := time.Now()
+	if numPurged, err := de.db.PurgeExpired(); err == nil {
+		if usage, err := de.db.Usage(); err == nil {
+			took := time.Now().Sub(start)
+			return &purgeResults{
+				uid:       de.uid,
+				numPurged: numPurged,
+				total:     usage.Total,
+				free:      usage.Free,
+				bytes:     usage.Free * usage.Size,
+				took:      took,
+			}, nil
+		} else {
+			return nil, errors.Wrap(err, "Purge Error getting db.Usage")
+		}
+	} else {
+		return nil, errors.Wrap(err, "Purge Error doing db.PurgeExpired")
+	}
+
+}

--- a/syncstorage/poolwrap_test.go
+++ b/syncstorage/poolwrap_test.go
@@ -1,6 +1,15 @@
 package syncstorage
 
-func newPoolwrap() *poolwrap { return newPoolwrapUID("1234567890") }
+import (
+	"strconv"
+	"time"
+)
+
+func newPoolwrap() *poolwrap {
+	uid := strconv.FormatInt(time.Now().UnixNano(), 36)
+	return newPoolwrapUID(uid)
+}
+
 func newPoolwrapUID(uid string) *poolwrap {
 
 	p, err := NewPool(getTempBase())

--- a/syncstorage/syncapi_test.go
+++ b/syncstorage/syncapi_test.go
@@ -605,9 +605,9 @@ func testApiDeleteEverything(db SyncApi, t *testing.T) {
 	assert.Exactly(ErrNotFound, err)
 	assert.Nil(b)
 
+	// collection data stick around, maybe an off chance the user
+	// makes it back into the server? it doesn't take up much space either way
 	cTest, err := db.GetCollectionId("my_collection")
-	assert.Exactly(ErrNotFound, err)
-	assert.Equal(0, cTest)
+	assert.Nil(err)
+	assert.Equal(100, cTest)
 }
-
-//func (db SyncApi, t *testing.T) {

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.1
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+In addition, `errors.Wrap` records the file and line where it was called, allowing the programmer to retrieve the path to the original error.
+
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to recurse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+     Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+Would you like to know more? Read the [blog post](http://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+MIT

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,241 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//      if err != nil {
+//              return err
+//      }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error. For example
+//
+//      _, err := ioutil.ReadAll(r)
+//      if err != nil {
+//              return errors.Wrap(err, "read failed")
+//      }
+//
+// In addition, errors.Wrap records the file and line where it was called,
+// allowing the programmer to retrieve the path to the original error.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//          Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"strings"
+)
+
+// location represents a program counter that
+// implements the Location() method.
+type location uintptr
+
+func (l location) Location() (string, int) {
+	pc := uintptr(l) - 1
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return "unknown", 0
+	}
+
+	file, line := fn.FileLine(pc)
+
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(fn.Name(), sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+
+	return file, line
+}
+
+// New returns an error that formats as the given text.
+func New(text string) error {
+	pc, _, _, _ := runtime.Caller(1)
+	return struct {
+		error
+		location
+	}{
+		errors.New(text),
+		location(pc),
+	}
+}
+
+type cause struct {
+	cause   error
+	message string
+}
+
+func (c cause) Error() string   { return c.Message() + ": " + c.Cause().Error() }
+func (c cause) Cause() error    { return c.cause }
+func (c cause) Message() string { return c.message }
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+func Errorf(format string, args ...interface{}) error {
+	pc, _, _, _ := runtime.Caller(1)
+	return struct {
+		error
+		location
+	}{
+		fmt.Errorf(format, args...),
+		location(pc),
+	}
+}
+
+// Wrap returns an error annotating the cause with message.
+// If cause is nil, Wrap returns nil.
+func Wrap(cause error, message string) error {
+	if cause == nil {
+		return nil
+	}
+	pc, _, _, _ := runtime.Caller(1)
+	return wrap(cause, message, pc)
+}
+
+// Wrapf returns an error annotating the cause with the format specifier.
+// If cause is nil, Wrapf returns nil.
+func Wrapf(cause error, format string, args ...interface{}) error {
+	if cause == nil {
+		return nil
+	}
+	pc, _, _, _ := runtime.Caller(1)
+	return wrap(cause, fmt.Sprintf(format, args...), pc)
+}
+
+func wrap(err error, msg string, pc uintptr) error {
+	return struct {
+		cause
+		location
+	}{
+		cause{
+			cause:   err,
+			message: msg,
+		},
+		location(pc),
+	}
+}
+
+type causer interface {
+	Cause() error
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type Causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}
+
+// Fprint prints the error to the supplied writer.
+// If the error implements the Causer interface described in Cause
+// Print will recurse into the error's cause.
+// If the error implements the inteface:
+//
+//     type Location interface {
+//            Location() (file string, line int)
+//     }
+//
+// Print will also print the file and line of the error.
+// If err is nil, nothing is printed.
+func Fprint(w io.Writer, err error) {
+	type location interface {
+		Location() (string, int)
+	}
+	type message interface {
+		Message() string
+	}
+
+	for err != nil {
+		if err, ok := err.(location); ok {
+			file, line := err.Location()
+			fmt.Fprintf(w, "%s:%d: ", file, line)
+		}
+		switch err := err.(type) {
+		case message:
+			fmt.Fprintln(w, err.Message())
+		default:
+			fmt.Fprintln(w, err.Error())
+		}
+
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+}

--- a/vendor/github.com/pkg/errors/errors_test.go
+++ b/vendor/github.com/pkg/errors/errors_test.go
@@ -1,0 +1,189 @@
+package errors
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		err  string
+		want error
+	}{
+		{"", fmt.Errorf("")},
+		{"foo", fmt.Errorf("foo")},
+		{"foo", New("foo")},
+		{"string with format specifiers: %v", errors.New("string with format specifiers: %v")},
+	}
+
+	for _, tt := range tests {
+		got := New(tt.err)
+		if got.Error() != tt.want.Error() {
+			t.Errorf("New.Error(): got: %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestWrapNil(t *testing.T) {
+	got := Wrap(nil, "no error")
+	if got != nil {
+		t.Errorf("Wrap(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWrap(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{Wrap(io.EOF, "read error"), "client error", "client error: read error: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := Wrap(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("Wrap(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+type nilError struct{}
+
+func (nilError) Error() string { return "nil error" }
+
+type causeError struct {
+	cause error
+}
+
+func (e *causeError) Error() string { return "cause error" }
+func (e *causeError) Cause() error  { return e.cause }
+
+func TestCause(t *testing.T) {
+	x := New("error")
+	tests := []struct {
+		err  error
+		want error
+	}{{
+		// nil error is nil
+		err:  nil,
+		want: nil,
+	}, {
+		// explicit nil error is nil
+		err:  (error)(nil),
+		want: nil,
+	}, {
+		// typed nil is nil
+		err:  (*nilError)(nil),
+		want: (*nilError)(nil),
+	}, {
+		// uncaused error is unaffected
+		err:  io.EOF,
+		want: io.EOF,
+	}, {
+		// caused error returns cause
+		err:  &causeError{cause: io.EOF},
+		want: io.EOF,
+	}, {
+		err:  x, // return from errors.New
+		want: x,
+	}}
+
+	for i, tt := range tests {
+		got := Cause(tt.err)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
+		}
+	}
+}
+
+func TestFprint(t *testing.T) {
+	x := New("error")
+	tests := []struct {
+		err  error
+		want string
+	}{{
+		// nil error is nil
+		err: nil,
+	}, {
+		// explicit nil error is nil
+		err: (error)(nil),
+	}, {
+		// uncaused error is unaffected
+		err:  io.EOF,
+		want: "EOF\n",
+	}, {
+		// caused error returns cause
+		err:  &causeError{cause: io.EOF},
+		want: "cause error\nEOF\n",
+	}, {
+		err:  x, // return from errors.New
+		want: "github.com/pkg/errors/errors_test.go:106: error\n",
+	}, {
+		err:  Wrap(x, "message"),
+		want: "github.com/pkg/errors/errors_test.go:128: message\ngithub.com/pkg/errors/errors_test.go:106: error\n",
+	}, {
+		err:  Wrap(Wrap(x, "message"), "another message"),
+		want: "github.com/pkg/errors/errors_test.go:131: another message\ngithub.com/pkg/errors/errors_test.go:131: message\ngithub.com/pkg/errors/errors_test.go:106: error\n",
+	}, {
+		err:  Wrapf(x, "message"),
+		want: "github.com/pkg/errors/errors_test.go:134: message\ngithub.com/pkg/errors/errors_test.go:106: error\n",
+	}}
+
+	for i, tt := range tests {
+		var w bytes.Buffer
+		Fprint(&w, tt.err)
+		got := w.String()
+		if got != tt.want {
+			t.Errorf("test %d: Fprint(w, %q): got %q, want %q", i+1, tt.err, got, tt.want)
+		}
+	}
+}
+
+func TestWrapfNil(t *testing.T) {
+	got := Wrapf(nil, "no error")
+	if got != nil {
+		t.Errorf("Wrapf(nil, \"no error\"): got %#v, expected nil", got)
+	}
+}
+
+func TestWrapf(t *testing.T) {
+	tests := []struct {
+		err     error
+		message string
+		want    string
+	}{
+		{io.EOF, "read error", "read error: EOF"},
+		{Wrapf(io.EOF, "read error without format specifiers"), "client error", "client error: read error without format specifiers: EOF"},
+		{Wrapf(io.EOF, "read error with %d format specifier", 1), "client error", "client error: read error with 1 format specifier: EOF"},
+	}
+
+	for _, tt := range tests {
+		got := Wrapf(tt.err, tt.message).Error()
+		if got != tt.want {
+			t.Errorf("Wrapf(%v, %q): got: %v, want %v", tt.err, tt.message, got, tt.want)
+		}
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{
+		{Errorf("read error without format specifiers"), "read error without format specifiers"},
+		{Errorf("read error with %d format specifier", 1), "read error with 1 format specifier"},
+	}
+
+	for _, tt := range tests {
+		got := tt.err.Error()
+		if got != tt.want {
+			t.Errorf("Errorf(%v): got: %q, want %q", tt.err, got, tt.want)
+		}
+	}
+}

--- a/vendor/github.com/pkg/errors/example_test.go
+++ b/vendor/github.com/pkg/errors/example_test.go
@@ -1,0 +1,71 @@
+package errors_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+)
+
+func ExampleNew() {
+	err := errors.New("whoops")
+	fmt.Println(err)
+
+	// Output: whoops
+}
+
+func ExampleNew_fprint() {
+	err := errors.New("whoops")
+	errors.Fprint(os.Stdout, err)
+
+	// Output: github.com/pkg/errors/example_test.go:18: whoops
+}
+
+func ExampleWrap() {
+	cause := errors.New("whoops")
+	err := errors.Wrap(cause, "oh noes")
+	fmt.Println(err)
+
+	// Output: oh noes: whoops
+}
+
+func fn() error {
+	e1 := errors.New("error")
+	e2 := errors.Wrap(e1, "inner")
+	e3 := errors.Wrap(e2, "middle")
+	return errors.Wrap(e3, "outer")
+}
+
+func ExampleCause() {
+	err := fn()
+	fmt.Println(err)
+	fmt.Println(errors.Cause(err))
+
+	// Output: outer: middle: inner: error
+	// error
+}
+
+func ExampleFprint() {
+	err := fn()
+	errors.Fprint(os.Stdout, err)
+
+	// Output: github.com/pkg/errors/example_test.go:36: outer
+	// github.com/pkg/errors/example_test.go:35: middle
+	// github.com/pkg/errors/example_test.go:34: inner
+	// github.com/pkg/errors/example_test.go:33: error
+}
+
+func ExampleWrapf() {
+	cause := errors.New("whoops")
+	err := errors.Wrapf(cause, "oh noes #%d", 2)
+	fmt.Println(err)
+
+	// Output: oh noes #2: whoops
+}
+
+func ExampleErrorf() {
+	err := errors.Errorf("whoops: %s", "foo")
+	errors.Fprint(os.Stdout, err)
+
+	// Output: github.com/pkg/errors/example_test.go:67: whoops: foo
+}


### PR DESCRIPTION
- before the DB is closed, use a background goroutine
  to delete expired BSOs
- vendor in github.com/pkg/errors
- refactor tests since closing is no longer synchronous
- fix bug where mozlog loses `msg` field
- fefactor pool.CloseOpenConnections => pool.Shutdown
