### PR TITLE
Test compatibility with Python server's behaviour

### DIFF
--- a/api/context_test.go
+++ b/api/context_test.go
@@ -324,6 +324,23 @@ func TestContextInfoCollectionsCache(t *testing.T) {
 	req, _ := http.NewRequest("PUT", "/1.5/"+uid+"/storage/bookmarks/bso2", body)
 	req.Header.Add("Content-Type", "application/json")
 	sendrequest(req, context)
+
+	// need some data in the cache
+	cId0, _ := context.Dispatch.GetCollectionId(uid, "bookmarks")
+	cId1, _ := context.Dispatch.GetCollectionId(uid, "meta")
+
+	{
+		payload := "boom"
+		_, err := context.Dispatch.PutBSO(uid, cId0, "test0", &payload, nil, nil)
+		if !assert.NoError(err) {
+			return
+		}
+		_, err = context.Dispatch.PutBSO(uid, cId1, "test1", &payload, nil, nil)
+		if !assert.NoError(err) {
+			return
+		}
+	}
+
 	r := request("GET", "http://test/1.5/"+uid+"/info/collections", nil, context)
 	assert.Equal("MISS", r.Header().Get("X-Weave-Cache"))
 
@@ -350,6 +367,7 @@ func TestContextInfoCollectionsCache(t *testing.T) {
 
 		r = request("GET", "http://test/1.5/"+uid+"/info/collections", nil, context)
 		assert.Equal("MISS", r.Header().Get("X-Weave-Cache"))
+
 		r = request("GET", "http://test/1.5/"+uid+"/info/collections", nil, context)
 		assert.Equal("HIT", r.Header().Get("X-Weave-Cache"))
 	}

--- a/circle.yml
+++ b/circle.yml
@@ -23,39 +23,56 @@ dependencies:
     # pre-compile go-sqlite3 to save time in testing/docker container building
     - cd "$B" && go install ./vendor/github.com/mattn/go-sqlite3
 
+    # create a version.json
+    - >
+        printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n'
+        "$CIRCLE_SHA1"
+        "$CIRCLE_TAG"
+        "$CIRCLE_PROJECT_USERNAME"
+        "$CIRCLE_PROJECT_REPONAME"
+        "$CIRCLE_BUILD_URL" > version.json
+    - cp version.json $CIRCLE_ARTIFACTS
+
+    # build a static binary
+    - cd "$B" && go build --ldflags '-extldflags "-static"' .
+
+    # build image and put its sha256 into artifacts to aid verification
+    - docker build -t "app:build" .
+    - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
+
+    - test -e $CIRCLE_ARTIFACTS/bin || mkdir -p $CIRCLE_ARTIFACTS/bin
+    - cp go-syncstorage $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1
+    - >
+        sha256sum $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1 |
+        awk '{print $1}' |
+        tee $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1-shasum256.txt
+
+    - docker pull mostlygeek/server-syncstorage:latest
+
 test:
   override:
     - cd "$B" && go vet ./token ./syncstorage ./api
     - cd "$B" && go test -v ./token ./syncstorage ./api
+    - >
+        docker run
+        --net=host
+        --detach=true
+        -e "PORT=8888"
+        -e "HOST=127.0.0.1"
+        -e "SECRETS=secret"
+        -e "DATA_DIR=:memory:"
+        app:build
+    - sleep 3
+    - >
+        docker run
+        --net=host
+        mostlygeek/server-syncstorage:latest
+        test_endpoint "http://127.0.0.1:8888#secret"
 
 deployment:
   hub_latest:
     branch: master
     commands:
-      # create a version.json
-      - >
-          printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n'
-          "$CIRCLE_SHA1"
-          "$CIRCLE_TAG"
-          "$CIRCLE_PROJECT_USERNAME"
-          "$CIRCLE_PROJECT_REPONAME"
-          "$CIRCLE_BUILD_URL" > version.json
-      - cp version.json $CIRCLE_ARTIFACTS
-
-      # build a static binary
-      - cd "$B" && go build --ldflags '-extldflags "-static"' .
-
-      # build image and put its sha256 into artifacts to aid verification
-      - docker build -t "app:build" .
-      - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
-
-      - test -e $CIRCLE_ARTIFACTS/bin || mkdir -p $CIRCLE_ARTIFACTS/bin
-      - cp go-syncstorage $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1
-      - >
-          sha256sum $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1 |
-          awk '{print $1}' |
-          tee $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_SHA1-shasum256.txt
-
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker tag app:build ${DOCKERHUB_REPO}:latest
       - docker push ${DOCKERHUB_REPO}:latest
@@ -63,31 +80,6 @@ deployment:
   hub_releases:
     tag: /.*/
     commands:
-      # create a version.json
-      - >
-          printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n'
-          "$CIRCLE_SHA1"
-          "$CIRCLE_TAG"
-          "$CIRCLE_PROJECT_USERNAME"
-          "$CIRCLE_PROJECT_REPONAME"
-          "$CIRCLE_BUILD_URL" > version.json
-      - cp version.json $CIRCLE_ARTIFACTS
-
-      # build a static binary
-      - cd "$B" && go build --ldflags '-extldflags "-static"' .
-
-      # build image and put its sha256 into artifacts to aid verification
-      - docker build -t "app:build" .
-      - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
-
-
-      - test -e $CIRCLE_ARTIFACTS/bin || mkdir -p $CIRCLE_ARTIFACTS/bin
-      - cp go-syncstorage "$CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_TAG"
-      - >
-          sha256sum $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_TAG |
-          awk '{print $1}' |
-          tee $CIRCLE_ARTIFACTS/bin/go-syncstorage-linux-amd64-$CIRCLE_TAG-shasum256.txt
-
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker tag app:build ${DOCKERHUB_REPO}:${CIRCLE_TAG}
       - docker push ${DOCKERHUB_REPO}:${CIRCLE_TAG}

--- a/config/config.go
+++ b/config/config.go
@@ -50,26 +50,28 @@ func init() {
 		log.Fatal("Config.Error: PORT invalid")
 	}
 
-	if _, err := os.Stat(Config.DataDir); os.IsNotExist(err) {
-		log.Fatal("Config Error: DATA_DIR does not exist")
-	}
+	if Config.DataDir != ":memory:" {
+		if _, err := os.Stat(Config.DataDir); os.IsNotExist(err) {
+			log.Fatal("Config Error: DATA_DIR does not exist")
+		}
 
-	stat, err := os.Stat(Config.DataDir)
-	if os.IsNotExist(err) {
-		log.Fatal("Config Error: DATA_DIR does not exist")
-	}
-	if !stat.IsDir() {
-		log.Fatal("Config Error: DATA_DIR is not a directory")
-	}
+		stat, err := os.Stat(Config.DataDir)
+		if os.IsNotExist(err) {
+			log.Fatal("Config Error: DATA_DIR does not exist")
+		}
+		if !stat.IsDir() {
+			log.Fatal("Config Error: DATA_DIR is not a directory")
+		}
 
-	Config.DataDir = filepath.Clean(Config.DataDir)
-	testfile := Config.DataDir + string(os.PathSeparator) + "test.writable"
-	f, err := os.Create(testfile)
-	if err != nil {
-		log.Fatal("Config Error: DATA_DIR is not writable")
-	} else {
-		f.Close()
-		os.Remove(testfile)
+		Config.DataDir = filepath.Clean(Config.DataDir)
+		testfile := Config.DataDir + string(os.PathSeparator) + "test.writable"
+		f, err := os.Create(testfile)
+		if err != nil {
+			log.Fatal("Config Error: DATA_DIR is not writable")
+		} else {
+			f.Close()
+			os.Remove(testfile)
+		}
 	}
 
 	switch Config.Log.Level {

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -341,7 +341,7 @@ func (d *DB) DeleteEverything() (err error) {
 	// delete all BSO data and keep the other metadata around
 	dml := `
 		DELETE FROM BSO;
-		INSERT INTO KeyValues (Key, Value) VALUES ("DELETE_EVERYTHING_DATE", ?);
+		INSERT OR REPLACE INTO KeyValues (Key, Value) VALUES ("DELETE_EVERYTHING_DATE", ?);
 		VACUUM;
 		`
 	_, err = d.db.Exec(dml, time.Now().Format(time.RFC3339))
@@ -360,7 +360,7 @@ func (d *DB) InfoCollections() (map[string]int, error) {
 	d.Lock()
 	defer d.Unlock()
 
-	rows, err := d.db.Query("SELECT Name,Modified FROM Collections ORDER BY Id")
+	rows, err := d.db.Query("SELECT Name,Modified FROM Collections WHERE Modified != 0")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- add support for `:memory:` for sqlite3 for testing purposes
- change InfoCollections behaviour to pass python functional tests
- change circle.yml to use python docker image for functional testing
- fix race in Pool.Stop() that causes Pool.Cleanup() to panic
  adds better interruption to goroutines in Pool.Start()
- change Pool.Cleanup to be a private method
- improve dependency on timing for TestPoolCleanupStop
