### PR TITLE
Fix and refactor pool cleanup algorithm

### DIFF
--- a/web/syncPoolHandler_test.go
+++ b/web/syncPoolHandler_test.go
@@ -126,7 +126,9 @@ func TestPoolElementGarbageCollector(t *testing.T) {
 
 	ttl := 5 * time.Millisecond
 	handler := NewSyncPoolHandler(":memory:", 1, ttl)
+
 	pool := handler.pools[0]
+	pool.gcCycleMax = 1 // ensure it happens fast (1ms)
 
 	pool.getElement(uniqueUID())
 	pool.getElement(uniqueUID())
@@ -134,6 +136,6 @@ func TestPoolElementGarbageCollector(t *testing.T) {
 	assert.Equal(2, pool.lru.Len())
 
 	pool.startGarbageCollector()
-	time.Sleep(3 * ttl)
+	time.Sleep(1500 * time.Millisecond)
 	assert.Equal(0, pool.lru.Len())
 }


### PR DESCRIPTION
- Bug: pool cleanup would use 100% of cpu since a `continue` was
  supposed to be a `return` (long infinite loop situation)
- Refactor: spread out cleaning up of expired handlers. More frequent
  cycles, limited number of handlers per cycle. Now every 1 to 10
  seconds the GC will run and clean up a max of 20% of the expired
  handlers
