### PR TITLE
Refactor web.SyncPoolHandler to have an upper bound on pool size

### DIFF
--- a/server.go
+++ b/server.go
@@ -33,7 +33,12 @@ func main() {
 	var router http.Handler
 
 	// The base functionality is the sync 1.5 api + legacy weave hacks
-	poolHandler := web.NewSyncPoolHandler(config.DataDir, 1, config.TTL)
+	poolHandler := web.NewSyncPoolHandler(&web.SyncPoolConfig{
+		Basepath:    config.DataDir,
+		NumPools:    config.Pool.Num,
+		TTL:         time.Duration(config.Pool.TTL) * time.Second,
+		MaxPoolSize: config.Pool.MaxSize,
+	})
 	router = web.NewWeaveHandler(poolHandler)
 
 	// All sync 1.5 access requires Hawk Authorization
@@ -74,9 +79,11 @@ func main() {
 	}
 
 	log.WithFields(log.Fields{
-		"addr": listenOn,
-		"PID":  os.Getpid(),
-		"TTL":  config.TTL,
+		"addr":          listenOn,
+		"PID":           os.Getpid(),
+		"POOL_NUM":      config.Pool.Num,
+		"POOL_MAX_SIZE": config.Pool.MaxSize,
+		"POOL_TTL":      config.Pool.TTL,
 	}).Info("HTTP Listening at " + listenOn)
 
 	err := httpdown.ListenAndServe(server, hd)

--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -24,10 +24,26 @@ type SyncPoolHandler struct {
 	pools []*handlerPool
 }
 
-func NewSyncPoolHandler(basepath string, numPools int, ttl time.Duration) *SyncPoolHandler {
-	pools := make([]*handlerPool, numPools, numPools)
-	for i := 0; i < numPools; i++ {
-		pools[i] = newHandlerPool(basepath, ttl)
+type SyncPoolConfig struct {
+	Basepath    string
+	NumPools    int
+	TTL         time.Duration
+	MaxPoolSize int
+}
+
+func NewDefaultSyncPoolConfig(basepath string) *SyncPoolConfig {
+	return &SyncPoolConfig{
+		Basepath:    basepath,
+		NumPools:    1,
+		TTL:         5 * time.Minute,
+		MaxPoolSize: 100,
+	}
+}
+
+func NewSyncPoolHandler(config *SyncPoolConfig) *SyncPoolHandler {
+	pools := make([]*handlerPool, config.NumPools, config.NumPools)
+	for i := 0; i < config.NumPools; i++ {
+		pools[i] = newHandlerPool(config.Basepath, config.TTL, config.MaxPoolSize)
 		pools[i].startGarbageCollector()
 	}
 

--- a/web/syncPoolHandler_test.go
+++ b/web/syncPoolHandler_test.go
@@ -8,6 +8,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func testSyncPoolConfig() *SyncPoolConfig {
+	return &SyncPoolConfig{
+		Basepath:    ":memory:",
+		NumPools:    1,
+		TTL:         5 * time.Minute,
+		MaxPoolSize: 10,
+	}
+}
+
 func TestSyncPoolHandlerStatusConflict(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -17,7 +26,7 @@ func TestSyncPoolHandlerStatusConflict(t *testing.T) {
 	assert := assert.New(t)
 
 	uid := uniqueUID()
-	handler := NewSyncPoolHandler(":memory:", 1, time.Hour)
+	handler := NewSyncPoolHandler(testSyncPoolConfig())
 
 	el, err := handler.pools[0].getElement(uid)
 	if !assert.NoError(err) {
@@ -40,7 +49,7 @@ func TestSyncPoolHandlerStatusConflict(t *testing.T) {
 
 func TestSyncPoolHandlerStop(t *testing.T) {
 	assert := assert.New(t)
-	handler := NewSyncPoolHandler(":memory:", 1, time.Hour)
+	handler := NewSyncPoolHandler(testSyncPoolConfig())
 
 	uids := []string{uniqueUID(), uniqueUID(), uniqueUID()}
 
@@ -76,7 +85,7 @@ func TestSyncPoolHandlerLRU(t *testing.T) {
 	uid1 := uniqueUID()
 	uid2 := uniqueUID()
 
-	handler := NewSyncPoolHandler(":memory:", 1, time.Hour)
+	handler := NewSyncPoolHandler(testSyncPoolConfig())
 	pool := handler.pools[0]
 
 	pool.getElement(uid0)
@@ -105,7 +114,7 @@ func TestSyncPoolHandlerLRU(t *testing.T) {
 func TestPoolElementLastUsed(t *testing.T) {
 	assert := assert.New(t)
 
-	handler := NewSyncPoolHandler(":memory:", 1, time.Hour)
+	handler := NewSyncPoolHandler(testSyncPoolConfig())
 	pool := handler.pools[0]
 
 	uid := uniqueUID()
@@ -125,7 +134,12 @@ func TestPoolElementGarbageCollector(t *testing.T) {
 	assert := assert.New(t)
 
 	ttl := 5 * time.Millisecond
-	handler := NewSyncPoolHandler(":memory:", 1, ttl)
+	handler := NewSyncPoolHandler(&SyncPoolConfig{
+		Basepath:    ":memory:",
+		NumPools:    1,
+		TTL:         ttl,
+		MaxPoolSize: 10,
+	})
 
 	pool := handler.pools[0]
 	pool.gcCycleMax = 1 // ensure it happens fast (1ms)


### PR DESCRIPTION
Fixes #88 
- add configuration options for controlling number, size and ttl of
  pools
- update sync pool configuration since to use a struct instead of a long
  list of params
