### PR TITLE
Remove web/syncPoolHandler's background TTL based cleanup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,6 @@ type LogConfig struct {
 
 type PoolConfig struct {
 	Num     int `envconfig:"default=0"`
-	TTL     int `envconfig:"default=500"`
 	MaxSize int `envconfig:"default=25"`
 }
 
@@ -95,10 +94,6 @@ func init() {
 
 	if Config.Pool.Num <= 0 {
 		Config.Pool.Num = runtime.NumCPU()
-	}
-
-	if Config.Pool.TTL <= 0 {
-		log.Fatal("POOL_TTL must be > 0")
 	}
 
 	Hostname = Config.Hostname

--- a/server.go
+++ b/server.go
@@ -36,7 +36,6 @@ func main() {
 	poolHandler := web.NewSyncPoolHandler(&web.SyncPoolConfig{
 		Basepath:    config.DataDir,
 		NumPools:    config.Pool.Num,
-		TTL:         time.Duration(config.Pool.TTL) * time.Second,
 		MaxPoolSize: config.Pool.MaxSize,
 	})
 	router = web.NewWeaveHandler(poolHandler)
@@ -83,7 +82,6 @@ func main() {
 		"PID":           os.Getpid(),
 		"POOL_NUM":      config.Pool.Num,
 		"POOL_MAX_SIZE": config.Pool.MaxSize,
-		"POOL_TTL":      config.Pool.TTL,
 	}).Info("HTTP Listening at " + listenOn)
 
 	err := httpdown.ListenAndServe(server, hd)

--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -43,8 +43,7 @@ func NewDefaultSyncPoolConfig(basepath string) *SyncPoolConfig {
 func NewSyncPoolHandler(config *SyncPoolConfig) *SyncPoolHandler {
 	pools := make([]*handlerPool, config.NumPools, config.NumPools)
 	for i := 0; i < config.NumPools; i++ {
-		pools[i] = newHandlerPool(config.Basepath, config.TTL, config.MaxPoolSize)
-		pools[i].startGarbageCollector()
+		pools[i] = newHandlerPool(config.Basepath, config.MaxPoolSize)
 	}
 
 	server := &SyncPoolHandler{


### PR DESCRIPTION
- When the pool is full, the just in time cleanup of old entries is fast
  and good and performant
- The extra TTL based expiry code and go-routine added extra complexity
  without enough benefit.
- Removing background TTL based go-routine cleanup simplifies and
  reduces code
