### PR TITLE
Fix for python test_bulk_update_of_ttls_without_sending_data

### DIFF
--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -816,7 +816,7 @@ func (d *DB) getBSOs(
 
 	cutOffTTL := Now()
 	query := "SELECT Id, SortIndex, Payload, Modified, TTL FROM BSO "
-	where := "WHERE CollectionId=? AND Modified > ? AND TTL>=?"
+	where := "WHERE CollectionId=? AND Modified > ? AND TTL > ?"
 	values := []interface{}{cId, newer, cutOffTTL}
 
 	if len(ids) > 0 {


### PR DESCRIPTION
- Test would randomly fail, due to timing issue for BSO expiry
- Change BSO expiry logic so TTL must be greater than the current time
  to be valid (not expired)
