### PR TITLE
Implement Batch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The server has a few knobs that can be tweaked.
 | `LOG_MOZLOG` | Can be `true` or `false`. Outputs logs in [mozlog](https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md) format. |
 | `LOG_DISABLE_HTTP` | Can be `true` or `false`. Disables logging of HTTP requests. |
 | `HOSTNAME` | Set a hostname value for mozlog output |
+| `LIMIT_MAX_REQUESTS_BYTES` | The maximum size in bytes of the overall HTTP request body that will be accepted by the server. |
 | `LIMIT_MAX_BSO_GET_LIMIT` |  Max BSOs that can be returned per GET request. Default: 2500. |
 | `LIMIT_MAX_POST_BYTES` |  Maximum size of a POST request. Default: 2097152 (2MB). |
 | `LIMIT_MAX_POST_RECORDS` |  Maximum number of BSOs per POST request. Default 100. |

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The server has a few knobs that can be tweaked.
 | `LIMIT_MAX_POST_RECORDS` |  Maximum number of BSOs per POST request. Default 100. |
 | `LIMIT_MAX_TOTAL_BYTES` |  Maximum total size of a POST batch job. Default: 26,214,400 (20MB). |
 | `LIMIT_MAX_TOTAL_RECORDS` | Maximum total BSOs in a POST batch job. Default 1000. |
+| `LIMIT_MAX_BATCH_TTL` | Maximum TTL for a batch to remain uncommitted in seconds. Default 7200 (2 hours). |
 
 ## Advanced Configuration
 Things that probably shouldn't be touched:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ The server has a few knobs that can be tweaked.
 | `LOG_MOZLOG` | Can be `true` or `false`. Outputs logs in [mozlog](https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md) format. |
 | `LOG_DISABLE_HTTP` | Can be `true` or `false`. Disables logging of HTTP requests. |
 | `HOSTNAME` | Set a hostname value for mozlog output |
+| `LIMIT_MAX_BSO_GET_LIMIT` |  Max BSOs that can be returned per GET request. Default: 2500. |
+| `LIMIT_MAX_POST_BYTES` |  Maximum size of a POST request. Default: 2097152 (2MB). |
+| `LIMIT_MAX_POST_RECORDS` |  Maximum number of BSOs per POST request. Default 100. |
+| `LIMIT_MAX_TOTAL_BYTES` |  Maximum total size of a POST batch job. Default: 26,214,400 (20MB). |
+| `LIMIT_MAX_TOTAL_RECORDS` | Maximum total BSOs in a POST batch job. Default 1000. |
 
 ## Advanced Configuration
 Things that probably shouldn't be touched:

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type UserHandlerConfig struct {
 	MaxPOSTBytes    int `envconfig:"default=0"`
 	MaxTotalRecords int `envconfig:"default=0"`
 	MaxTotalBytes   int `envconfig:"default=0"`
+	MaxBatchTTL     int `envconfig:"default=0"`
 }
 
 type PoolConfig struct {
@@ -130,6 +131,9 @@ func init() {
 	}
 	if Config.Limit.MaxTotalBytes < 0 {
 		log.Fatal("LIMIT_MAX_TOTAL_BYTES must be >= 0")
+	}
+	if Config.Limit.MaxBatchTTL < 0 {
+		log.Fatal("LIMIT_MAX_BATCH_TTL must be > 0")
 	}
 
 	Hostname = Config.Hostname

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,15 @@ type LogConfig struct {
 	DisableHTTP bool `envconfig:"default=false"`
 }
 
+// configures limits for web/SyncUserHandler
+type UserHandlerConfig struct {
+	MaxBSOGetLimit  int `envconfig:"default=0"`
+	MaxPOSTRecords  int `envconfig:"default=0"`
+	MaxPOSTBytes    int `envconfig:"default=0"`
+	MaxTotalRecords int `envconfig:"default=0"`
+	MaxTotalBytes   int `envconfig:"default=0"`
+}
+
 type PoolConfig struct {
 	Num     int `envconfig:"default=0"`
 	MaxSize int `envconfig:"default=25"`
@@ -38,6 +47,10 @@ var Config struct {
 
 	// Enable the pprof web endpoint /debug/pprof/
 	EnablePprof bool `envconfig:"default=false"`
+
+	// SyncUserHandler limits / configuration
+	// available as LIMIT_x
+	Limit *UserHandlerConfig
 }
 
 // so we can use config.Port and not config.Config.Port
@@ -50,6 +63,8 @@ var (
 	Secrets     []string
 	Pool        *PoolConfig
 	EnablePprof bool
+
+	Limit *UserHandlerConfig
 
 	DisableHTTPLogs bool
 )
@@ -101,6 +116,22 @@ func init() {
 		Config.Pool.Num = runtime.NumCPU()
 	}
 
+	if Config.Limit.MaxBSOGetLimit < 0 {
+		log.Fatal("LIMIT_MAX_BSO_GET_LIMIT must be >= 0")
+	}
+	if Config.Limit.MaxPOSTRecords < 0 {
+		log.Fatal("LIMIT_MAX_POST_RECORDS must be >= 0")
+	}
+	if Config.Limit.MaxPOSTBytes < 0 {
+		log.Fatal("LIMIT_MAX_MAX_POST_BYTES must be >= 0")
+	}
+	if Config.Limit.MaxTotalRecords < 0 {
+		log.Fatal("LIMIT_MAX_TOTAL_RECORDS must be >= 0")
+	}
+	if Config.Limit.MaxTotalBytes < 0 {
+		log.Fatal("LIMIT_MAX_TOTAL_BYTES must be >= 0")
+	}
+
 	Hostname = Config.Hostname
 	Log = Config.Log
 	Host = Config.Host
@@ -109,4 +140,5 @@ func init() {
 	DataDir = Config.DataDir
 	Pool = Config.Pool
 	EnablePprof = Config.EnablePprof
+	Limit = Config.Limit
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type LogConfig struct {
 
 // configures limits for web/SyncUserHandler
 type UserHandlerConfig struct {
+	MaxRequestBytes int `envconfig:"default=0"`
 	MaxBSOGetLimit  int `envconfig:"default=0"`
 	MaxPOSTRecords  int `envconfig:"default=0"`
 	MaxPOSTBytes    int `envconfig:"default=0"`

--- a/server.go
+++ b/server.go
@@ -34,6 +34,9 @@ func main() {
 	var router http.Handler
 
 	syncLimitConfig := web.NewDefaultSyncUserHandlerConfig()
+	if config.Limit.MaxRequestBytes != 0 {
+		syncLimitConfig.MaxRequestBytes = config.Limit.MaxRequestBytes
+	}
 	if config.Limit.MaxBSOGetLimit != 0 {
 		syncLimitConfig.MaxBSOGetLimit = config.Limit.MaxBSOGetLimit
 	}
@@ -110,6 +113,7 @@ func main() {
 		"LIMIT_MAX_POST_BYTES":    syncLimitConfig.MaxPOSTBytes,
 		"LIMIT_MAX_TOTAL_RECORDS": syncLimitConfig.MaxTotalRecords,
 		"LIMIT_MAX_TOTAL_BYTES":   syncLimitConfig.MaxTotalBytes,
+		"LIMIT_MAX_REQUEST_BYTES": syncLimitConfig.MaxRequestBytes,
 		"LIMIT_MAX_BATCH_TTL":     fmt.Sprintf("%d seconds", syncLimitConfig.MaxBatchTTL/1000),
 	}).Info("HTTP Listening at " + listenOn)
 

--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -47,6 +48,9 @@ func main() {
 	}
 	if config.Limit.MaxTotalRecords != 0 {
 		syncLimitConfig.MaxTotalRecords = config.Limit.MaxTotalRecords
+	}
+	if config.Limit.MaxBatchTTL != 0 {
+		syncLimitConfig.MaxBatchTTL = config.Limit.MaxBatchTTL * 1000
 	}
 
 	// The base functionality is the sync 1.5 api + legacy weave hacks
@@ -106,6 +110,7 @@ func main() {
 		"LIMIT_MAX_POST_BYTES":    syncLimitConfig.MaxPOSTBytes,
 		"LIMIT_MAX_TOTAL_RECORDS": syncLimitConfig.MaxTotalRecords,
 		"LIMIT_MAX_TOTAL_BYTES":   syncLimitConfig.MaxTotalBytes,
+		"LIMIT_MAX_BATCH_TTL":     fmt.Sprintf("%d seconds", syncLimitConfig.MaxBatchTTL/1000),
 	}).Info("HTTP Listening at " + listenOn)
 
 	err := httpdown.ListenAndServe(server, hd)

--- a/syncstorage/BSO_test.go
+++ b/syncstorage/BSO_test.go
@@ -21,13 +21,13 @@ var (
 func TestBSOtoJson(t *testing.T) {
 	j, err := json.Marshal(bso)
 	if assert.NoError(t, err) {
-		assert.Equal(t, `{"id":"Testing","modified":1000000000000.10,"payload":"Put in a quote: \"to make it interesting\"\n\t\t\tand some new lines\n\t\t\t"}`, string(j))
+		assert.Equal(t, `{"id":"Testing","modified":1000000000000.10,"payload":"Put in a quote: \"to make it interesting\"\n\t\t\tand some new lines\n\t\t\t","sortindex":11}`, string(j))
 	}
 
 	// make sure refs work too
 	j, err = json.Marshal(&bso)
 	if assert.NoError(t, err) {
-		assert.Equal(t, `{"id":"Testing","modified":1000000000000.10,"payload":"Put in a quote: \"to make it interesting\"\n\t\t\tand some new lines\n\t\t\t"}`, string(j))
+		assert.Equal(t, `{"id":"Testing","modified":1000000000000.10,"payload":"Put in a quote: \"to make it interesting\"\n\t\t\tand some new lines\n\t\t\t","sortindex":11}`, string(j))
 	}
 }
 

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -459,9 +459,9 @@ func (d *DB) InfoCollectionCounts() (map[string]int, error) {
 type PostBSOInput []*PutBSOInput
 type PutBSOInput struct {
 	Id        string  `json:"id"`
-	Payload   *string `json:"payload"`
-	TTL       *int    `json:"ttl"`
-	SortIndex *int    `json:"sortindex"`
+	Payload   *string `json:"payload,omitempty"`
+	TTL       *int    `json:"ttl,omitempty"`
+	SortIndex *int    `json:"sortindex,omitempty"`
 }
 
 func NewPutBSOInput(id string, payload *string, sortIndex, ttl *int) *PutBSOInput {
@@ -905,7 +905,7 @@ func (d *DB) getBSO(tx dbTx, cId int, bId string) (*BSO, error) {
 
 	b := &BSO{Id: bId}
 
-	query := "SELECT SortIndex, Payload, Modified, TTL FROM BSO WHERE CollectionId=? and Id=? and TTL > ?"
+	query := "SELECT SortIndex, Payload, Modified, TTL FROM BSO WHERE CollectionId=? and Id=? and TTL >= ?"
 	err := tx.QueryRow(query, cId, bId, Now()).Scan(&b.SortIndex, &b.Payload, &b.Modified, &b.TTL)
 
 	if err != nil {

--- a/syncstorage/db_batch.go
+++ b/syncstorage/db_batch.go
@@ -79,6 +79,24 @@ func (d *DB) BatchAppend(id, cId int, data string) (err error) {
 	return
 }
 
+// BatchExists checks if a batch exists without loading all the data from disk
+func (d *DB) BatchExists(id, cId int) (bool, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	var foundId int
+	err := d.db.QueryRow("SELECT Id FROM Batches WHERE Id=? AND CollectionId=?", id, cId).Scan(&foundId)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+
+		return false, errors.Wrap(err, "BatchExists failed")
+	}
+
+	return true, nil
+}
+
 func (d *DB) BatchLoad(id, cId int) (*BatchRecord, error) {
 	d.Lock()
 	defer d.Unlock()

--- a/syncstorage/db_batch.go
+++ b/syncstorage/db_batch.go
@@ -114,3 +114,17 @@ func (d *DB) BatchRemove(id int) error {
 	tx.Commit()
 	return nil
 }
+
+func (d *DB) BatchPurge(TTL int) (int, error) {
+
+	d.Lock()
+	defer d.Unlock()
+
+	r, err := d.db.Exec("DELETE FROM Batches WHERE (? - Modified) >= ?", Now(), TTL)
+	if err != nil {
+		return 0, err
+	}
+
+	purged, err := r.RowsAffected()
+	return int(purged), err
+}

--- a/syncstorage/db_batch.go
+++ b/syncstorage/db_batch.go
@@ -1,0 +1,116 @@
+package syncstorage
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrBatchNotFound = errors.New("Batch Not Found")
+)
+
+type BatchRecord struct {
+	Id           int
+	CollectionId int
+	BSOS         string
+	Modified     int
+}
+
+// BatchCreate creates a new batch
+func (d *DB) BatchCreate(cId int, data string) (int, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		return 0, errors.Wrap(err, "BatchCreate: Failed creating transaction")
+	}
+
+	results, err := tx.Exec("INSERT INTO Batches(CollectionId, Modified,BSOS) VALUES (?, ?, ?)",
+		cId,
+		Now(),
+		data,
+	)
+
+	var batchId64 int64
+	if err == nil {
+		batchId64, err = results.LastInsertId()
+	}
+
+	if err != nil {
+		tx.Rollback()
+		return 0, errors.Wrap(err, "Could not create new batch")
+	}
+
+	tx.Commit()
+	return int(batchId64), nil
+}
+
+// BatchAppend adds data to the BSOS column for a batch id
+func (d *DB) BatchAppend(id, cId int, data string) (err error) {
+	d.Lock()
+	defer d.Unlock()
+
+	tx, err := d.db.Begin()
+
+	if err != nil {
+		return errors.Wrap(err, "BatchAppend: Failed creating transaction")
+	}
+
+	result, err := tx.Exec("UPDATE Batches SET Modified=?, BSOS=BSOS || ? WHERE Id=? AND CollectionId=?",
+		Now(),
+		data,
+		id,
+		cId,
+	)
+
+	if err != nil {
+		tx.Rollback()
+		return errors.Wrap(err, "Could not append to batch")
+	}
+
+	if affected, _ := result.RowsAffected(); affected == 0 {
+		tx.Rollback()
+		return ErrBatchNotFound
+	}
+
+	tx.Commit()
+	return
+}
+
+func (d *DB) BatchLoad(id, cId int) (*BatchRecord, error) {
+	d.Lock()
+	defer d.Unlock()
+
+	r := &BatchRecord{Id: id}
+
+	err := d.db.QueryRow("SELECT CollectionId, Modified, BSOS FROM Batches WHERE Id=? AND CollectionId=?", id, cId).Scan(&r.CollectionId, &r.Modified, &r.BSOS)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrBatchNotFound
+		}
+
+		return nil, errors.Wrap(err, "Failed to SELECT Batch")
+	}
+
+	return r, nil
+}
+
+func (d *DB) BatchRemove(id int) error {
+	d.Lock()
+	defer d.Unlock()
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec("DELETE FROM Batches WHERE Id=?", id); err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	tx.Commit()
+	return nil
+}

--- a/syncstorage/db_batch_test.go
+++ b/syncstorage/db_batch_test.go
@@ -142,3 +142,22 @@ func TestBatchPurge(t *testing.T) {
 	}
 
 }
+
+func TestBatchExists(t *testing.T) {
+
+	assert := assert.New(t)
+
+	db, _ := getTestDB()
+	batchId, err := db.BatchCreate(1, "hello")
+	if !assert.NoError(err) {
+		return
+	}
+
+	exists, err := db.BatchExists(batchId, 1)
+	assert.True(exists)
+	assert.NoError(err)
+
+	notExists, err := db.BatchExists(2, 1)
+	assert.False(notExists)
+	assert.NoError(err)
+}

--- a/syncstorage/db_batch_test.go
+++ b/syncstorage/db_batch_test.go
@@ -1,0 +1,114 @@
+package syncstorage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchCreate(t *testing.T) {
+	assert := assert.New(t)
+	data := "some data\n"
+
+	db, err := getTestDB()
+	if !assert.NoError(err) {
+		return
+	}
+	cId := 1
+	batchId, err := db.BatchCreate(cId, data)
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Equal(1, batchId)
+
+	batch, err := db.BatchLoad(batchId, cId)
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Equal(batchId, batch.Id)
+	assert.Equal(data, batch.BSOS)
+	assert.True(batch.Modified > 0)
+}
+
+func TestBatchUpdate(t *testing.T) {
+	assert := assert.New(t)
+	data0 := "data0\n"
+	data1 := "data1\n"
+	cId := 1
+
+	db, _ := getTestDB()
+	batchId, err := db.BatchCreate(cId, data0)
+	if !assert.NoError(err) {
+		return
+	}
+
+	batchOrig, err := db.BatchLoad(batchId, cId)
+
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Equal(data0, batchOrig.BSOS)
+
+	// make sure we have a different timestamp
+	time.Sleep(10 * time.Millisecond)
+
+	err = db.BatchAppend(batchId, cId, data1)
+	if !assert.NoError(err) {
+		return
+	}
+
+	batchUpdated, err := db.BatchLoad(batchId, cId)
+	if !assert.NoError(err) {
+		return
+	}
+
+	assert.Equal(data0+data1, batchUpdated.BSOS)
+	assert.NotEqual(batchOrig.Modified, batchUpdated.Modified)
+}
+
+func TestBatchUpdateInvalidId(t *testing.T) {
+	assert := assert.New(t)
+	db, _ := getTestDB()
+	cId := 1
+
+	err := db.BatchAppend(22, cId, "test")
+	assert.Equal(ErrBatchNotFound, err)
+
+	batchId, err := db.BatchCreate(cId, "test")
+	if !assert.NoError(err) {
+		return
+	}
+
+	// correct batch id, wrong collection
+	err = db.BatchAppend(batchId, cId+1, "test")
+	assert.Equal(ErrBatchNotFound, err)
+}
+
+func TestBatchRemove(t *testing.T) {
+	assert := assert.New(t)
+	data := "some data\n"
+
+	db, err := getTestDB()
+	if !assert.NoError(err) {
+		return
+	}
+	cId := 1
+	batchId, err := db.BatchCreate(cId, data)
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Equal(1, batchId)
+
+	{
+		err := db.BatchRemove(batchId)
+		if !assert.NoError(err) {
+			return
+		}
+	}
+
+	{
+		_, err := db.BatchLoad(batchId, cId)
+		assert.Equal(ErrBatchNotFound, err)
+	}
+}

--- a/syncstorage/db_batch_test.go
+++ b/syncstorage/db_batch_test.go
@@ -112,3 +112,33 @@ func TestBatchRemove(t *testing.T) {
 		assert.Equal(ErrBatchNotFound, err)
 	}
 }
+
+func TestBatchPurge(t *testing.T) {
+	assert := assert.New(t)
+	data := "some data\n"
+
+	db, err := getTestDB()
+	if !assert.NoError(err) {
+		return
+	}
+	cId := 1
+
+	batchId, err := db.BatchCreate(cId, data)
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Equal(1, batchId)
+
+	{
+		time.Sleep(time.Millisecond * 10)
+		numPurged, err := db.BatchPurge(1) // purge everything older than a ms
+		if !assert.NoError(err) {
+			return
+		}
+		assert.Equal(1, numPurged)
+
+		_, err = db.BatchLoad(batchId, cId)
+		assert.Equal(ErrBatchNotFound, err)
+	}
+
+}

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -1004,7 +1004,7 @@ func TestUsageStats(t *testing.T) {
 			if assert.NoError(err) {
 
 				// numbers pulled from previous tests
-				assert.Equal(8, pageStats.Total)   // total pages in database
+				assert.Equal(9, pageStats.Total)   // total pages in database
 				assert.Equal(0, pageStats.Free)    // unused pages (from delete)
 				assert.Equal(4096, pageStats.Size) // bytes/page
 			}
@@ -1055,7 +1055,7 @@ func TestOptimize(t *testing.T) {
 			assert.Equal(3, purged)
 			stats, err := db.Usage()
 			if assert.NoError(err) {
-				assert.Equal(27, stats.FreePercent()) // we know this from a previous test ;)
+				assert.Equal(25, stats.FreePercent()) // we know this from a previous test ;)
 				vac, err := db.Optimize(20)
 				assert.NoError(err)
 				assert.True(vac)

--- a/syncstorage/schemas.go
+++ b/syncstorage/schemas.go
@@ -21,7 +21,7 @@ const SCHEMA_0 = `
 	);
 
 	CREATE TABLE Collections (
-	  -- storage an integer to save some space
+	  -- store as an integer to save some space
 	  Id		INTEGER PRIMARY KEY ASC AUTOINCREMENT,
 	  Name      VARCHAR(32) UNIQUE,
 
@@ -42,6 +42,14 @@ const SCHEMA_0 = `
 		(11, "addons"),
 		-- forces new collections to start at 100
 		(99, "-push-");
+
+	-- stores batch uploads. BSOS should be text/newline of BSO json blobs
+	CREATE TABLE Batches (
+		Id				INTEGER PRIMARY KEY ASC AUTOINCREMENT,
+		CollectionId	INTEGER NOT NULL,
+		Modified		INTEGER NOT NULL,
+		BSOS			TEXT NOT NULL DEFAULT ''
+	);
 
 	CREATE TABLE KeyValues (
 		Key VARCHAR(32) NOT NULL,

--- a/web/misc.go
+++ b/web/misc.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -36,9 +37,77 @@ func extractUID(path string) string {
 // used to massage post results into JSON
 // the client expects
 type PostResults struct {
-	Modified string              `json:"modified"`
-	Success  []string            `json:"success"`
-	Failed   map[string][]string `json:"failed"`
+	Batch    int
+	Modified int
+	Success  []string
+	Failed   map[string][]string
+}
+
+// MarshalJSON manually creates the JSON string since the modified needs to be
+// converted in the python (ugh) timeformat required for sync 1.5. Which means no quotes
+func (p *PostResults) MarshalJSON() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	buf.WriteString(`{"modified":`)
+	buf.WriteString(syncstorage.ModifiedToString(p.Modified))
+	buf.WriteString(",")
+	if len(p.Success) == 0 {
+		buf.WriteString(`"success":null`)
+	} else {
+		buf.WriteString(`"success":`)
+		data, err := json.Marshal(p.Success)
+		if err != nil {
+			return nil, err
+		}
+		_, err = buf.Write(data)
+		if err != nil {
+			return nil, errors.Wrap(err, "Could not encode PostResults.Success")
+		}
+	}
+
+	buf.WriteString(",")
+	if len(p.Failed) == 0 {
+		buf.WriteString(`"failed":null`)
+	} else {
+		buf.WriteString(`"failed":`)
+		data, err := json.Marshal(p.Failed)
+		if err != nil {
+			return nil, err
+		}
+		_, err = buf.Write(data)
+		if err != nil {
+			return nil, errors.Wrap(err, "Could not encode PostResults.Failed")
+		}
+	}
+
+	if p.Batch > 0 {
+		buf.WriteString(`,"batch":`)
+		buf.WriteString(strconv.Itoa(p.Batch))
+	}
+
+	buf.WriteString("}")
+
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON reverses custom formatting from MarshalJSON
+func (p *PostResults) UnmarshalJSON(data []byte) error {
+	var tmp struct {
+		Modified float64
+		Batch    int
+		Success  []string
+		Failed   map[string][]string
+	}
+
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	p.Modified = int(tmp.Modified * 1000)
+	p.Batch = tmp.Batch
+	p.Success = tmp.Success
+	p.Failed = tmp.Failed
+	return nil
 }
 
 type parseError struct {

--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -22,6 +22,8 @@ type SyncPoolHandler struct {
 	// use multiple pools to spread lock
 	// contention for parallel requests
 	pools []*handlerPool
+
+	userHandlerConfig *SyncUserHandlerConfig
 }
 
 type SyncPoolConfig struct {
@@ -40,14 +42,19 @@ func NewDefaultSyncPoolConfig(basepath string) *SyncPoolConfig {
 	}
 }
 
-func NewSyncPoolHandler(config *SyncPoolConfig) *SyncPoolHandler {
+func NewSyncPoolHandler(config *SyncPoolConfig, userHandlerConfig *SyncUserHandlerConfig) *SyncPoolHandler {
 	pools := make([]*handlerPool, config.NumPools, config.NumPools)
 	for i := 0; i < config.NumPools; i++ {
 		pools[i] = newHandlerPool(config.Basepath, config.MaxPoolSize)
 	}
 
+	if userHandlerConfig == nil {
+		userHandlerConfig = NewDefaultSyncUserHandlerConfig()
+	}
+
 	server := &SyncPoolHandler{
-		pools: pools,
+		pools:             pools,
+		userHandlerConfig: userHandlerConfig,
 	}
 
 	return server

--- a/web/syncPoolHandler_elements.go
+++ b/web/syncPoolHandler_elements.go
@@ -146,7 +146,7 @@ func (p *handlerPool) getElement(uid string) (*poolElement, error) {
 
 		element = &poolElement{
 			uid:     uid,
-			handler: NewSyncUserHandler(uid, db),
+			handler: NewSyncUserHandler(uid, db, nil),
 		}
 
 		p.elements[uid] = element

--- a/web/syncPoolHandler_test.go
+++ b/web/syncPoolHandler_test.go
@@ -24,7 +24,7 @@ func TestSyncPoolHandlerStatusConflict(t *testing.T) {
 	assert := assert.New(t)
 
 	uid := uniqueUID()
-	handler := NewSyncPoolHandler(testSyncPoolConfig())
+	handler := NewSyncPoolHandler(testSyncPoolConfig(), nil)
 
 	el, err := handler.pools[0].getElement(uid)
 	if !assert.NoError(err) {
@@ -47,7 +47,7 @@ func TestSyncPoolHandlerStatusConflict(t *testing.T) {
 
 func TestSyncPoolHandlerStop(t *testing.T) {
 	assert := assert.New(t)
-	handler := NewSyncPoolHandler(testSyncPoolConfig())
+	handler := NewSyncPoolHandler(testSyncPoolConfig(), nil)
 
 	uids := []string{uniqueUID(), uniqueUID(), uniqueUID()}
 
@@ -83,7 +83,7 @@ func TestSyncPoolHandlerLRU(t *testing.T) {
 	uid1 := uniqueUID()
 	uid2 := uniqueUID()
 
-	handler := NewSyncPoolHandler(testSyncPoolConfig())
+	handler := NewSyncPoolHandler(testSyncPoolConfig(), nil)
 	pool := handler.pools[0]
 
 	pool.getElement(uid0)
@@ -110,7 +110,7 @@ func TestSyncPoolHandlerLRU(t *testing.T) {
 }
 
 func TestSyncPoolCleanupHandlers(t *testing.T) {
-	handler := NewSyncPoolHandler(testSyncPoolConfig())
+	handler := NewSyncPoolHandler(testSyncPoolConfig(), nil)
 	pool := handler.pools[0]
 	pool.getElement("1")
 	pool.getElement("2")

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -23,6 +23,7 @@ type SyncUserHandlerConfig struct {
 	MaxBSOGetLimit int
 
 	// API Limits
+	MaxRequestBytes int
 	MaxPOSTRecords  int
 	MaxPOSTBytes    int
 	MaxTotalRecords int
@@ -36,6 +37,7 @@ func NewDefaultSyncUserHandlerConfig() *SyncUserHandlerConfig {
 		MaxBSOGetLimit: 2500,
 
 		// API Limits
+		MaxRequestBytes: 2 * 1024 * 1024,
 		MaxPOSTRecords:  100,
 		MaxPOSTBytes:    2 * 1024 * 1024,
 		MaxTotalRecords: 1000,
@@ -328,11 +330,17 @@ func (s *SyncUserHandler) hInfoCollectionCounts(w http.ResponseWriter, r *http.R
 
 func (s *SyncUserHandler) hInfoConfiguration(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, `{"max_post_records":%d,"max_post_bytes":%d,"max_total_records":%d,"max_total_bytes":%d}`,
+	fmt.Fprintf(w, `{
+		"max_post_records":%d,
+		"max_post_bytes":%d,
+		"max_total_records":%d,
+		"max_total_bytes":%d,
+		"max_request_bytes":%d}`,
 		s.config.MaxPOSTRecords,
 		s.config.MaxPOSTBytes,
 		s.config.MaxTotalRecords,
 		s.config.MaxTotalBytes,
+		s.config.MaxRequestBytes,
 	)
 }
 

--- a/web/syncUserHandler_misc.go
+++ b/web/syncUserHandler_misc.go
@@ -1,0 +1,96 @@
+package web
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/mozilla-services/go-syncstorage/syncstorage"
+	"github.com/pkg/errors"
+)
+
+// RequestToPostBSOInput extracts and unmarshals request.Body into a syncstorage.PostBSOInput. It
+// returns a PostResults as well since it also validates BSOs
+func RequestToPostBSOInput(r *http.Request) (
+	syncstorage.PostBSOInput,
+	*syncstorage.PostResults,
+	error,
+) {
+
+	// bsoToBeProcessed will actually get sent to the DB
+	bsoToBeProcessed := syncstorage.PostBSOInput{}
+	results := syncstorage.NewPostResults(syncstorage.Now())
+
+	// a list of all the raw json encoded BSOs
+	var raw []json.RawMessage
+
+	if ct := r.Header.Get("Content-Type"); ct == "application/json" || ct == "text/plain" {
+		decoder := json.NewDecoder(r.Body)
+		err := decoder.Decode(&raw)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "Could not unmarshal Request body")
+		}
+	} else { // deal with application/newlines
+		raw = ReadNewlineJSON(r.Body)
+	}
+
+	for _, rawJSON := range raw {
+		var b syncstorage.PutBSOInput
+		if parseErr := parseIntoBSO(rawJSON, &b); parseErr == nil {
+			bsoToBeProcessed = append(bsoToBeProcessed, &b)
+		} else {
+			// couldn't parse a BSO into something real
+			// abort immediately
+			if parseErr.field == "-" { // json error, not an object
+				return nil, nil, errors.Wrap(parseErr, "Could not unmarshal BSO")
+			}
+
+			results.AddFailure(parseErr.bId, fmt.Sprintf("invalid %s", parseErr.field))
+		}
+	}
+
+	// change TTL from seconds (what clients sends)
+	// to milliseconds (what the DB uses)
+	for _, p := range bsoToBeProcessed {
+		if p.TTL != nil {
+			tmp := *p.TTL * 1000
+			p.TTL = &tmp
+		}
+	}
+
+	return bsoToBeProcessed, results, nil
+}
+
+// ReadNewlineDelimitedJSON takes newline separate JSON and produces
+// produces an array of json.RawMessage
+func ReadNewlineJSON(data io.Reader) []json.RawMessage {
+	raw := []json.RawMessage{}
+	scanner := bufio.NewScanner(data)
+	for scanner.Scan() {
+		bsoBytes := scanner.Bytes()
+
+		// ignore empty lines
+		if len(strings.TrimSpace(string(bsoBytes))) == 0 {
+			continue
+		}
+
+		raw = append(raw, bsoBytes)
+	}
+
+	return raw
+}
+
+func GetBatchIdAndCommit(r *http.Request) (batchFound bool, batchId string, batchCommit bool) {
+	if vals, ok := r.URL.Query()["batch"]; ok && len(vals) > 0 {
+		batchId = vals[0]
+		batchFound = true
+	}
+
+	// any value is ok for commit param, as long as it exists
+	_, batchCommit = r.URL.Query()["commit"]
+
+	return
+}

--- a/web/syncUserHandler_test.go
+++ b/web/syncUserHandler_test.go
@@ -38,6 +38,7 @@ func TestSyncUserHandlerInfoConfiguration(t *testing.T) {
 		MaxPOSTRecords:  2,
 		MaxTotalBytes:   3,
 		MaxTotalRecords: 4,
+		MaxRequestBytes: 5,
 	}
 
 	handler := NewSyncUserHandler(uid, db, config)
@@ -48,7 +49,6 @@ func TestSyncUserHandlerInfoConfiguration(t *testing.T) {
 
 	jdata := make(map[string]int)
 	if err := json.Unmarshal(resp.Body.Bytes(), &jdata); assert.NoError(err) {
-
 		if val, ok := jdata["max_post_bytes"]; assert.True(ok, "max_post_bytes") {
 			assert.Equal(val, config.MaxPOSTBytes)
 		}
@@ -60,6 +60,9 @@ func TestSyncUserHandlerInfoConfiguration(t *testing.T) {
 		}
 		if val, ok := jdata["max_total_records"]; assert.True(ok, "max_total_records") {
 			assert.Equal(val, config.MaxTotalRecords)
+		}
+		if val, ok := jdata["max_request_bytes"]; assert.True(ok, "max_request_bytes") {
+			assert.Equal(val, config.MaxRequestBytes)
 		}
 	}
 }

--- a/web/syncUserHandler_test.go
+++ b/web/syncUserHandler_test.go
@@ -1,7 +1,10 @@
 package web
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/mozilla-services/go-syncstorage/syncstorage"
@@ -12,7 +15,7 @@ func TestSyncUserHandlerStopPurgeClose(t *testing.T) {
 	assert := assert.New(t)
 	uid := uniqueUID()
 	db, _ := syncstorage.NewDB(":memory:")
-	handler := NewSyncUserHandler(uid, db)
+	handler := NewSyncUserHandler(uid, db, nil)
 
 	handler.StopHTTP()
 
@@ -21,4 +24,181 @@ func TestSyncUserHandlerStopPurgeClose(t *testing.T) {
 	resp := request("GET", url, nil, handler)
 	assert.Equal(http.StatusServiceUnavailable, resp.Code)
 	assert.NotEqual("", resp.Header().Get("Retry-After"))
+}
+
+func TestSyncUserHandlerInfoConfiguration(t *testing.T) {
+
+	assert := assert.New(t)
+	uid := uniqueUID()
+	db, _ := syncstorage.NewDB(":memory:")
+
+	// make sure values propagate from the configuration
+	config := &SyncUserHandlerConfig{
+		MaxPOSTBytes:    1,
+		MaxPOSTRecords:  2,
+		MaxTotalBytes:   3,
+		MaxTotalRecords: 4,
+	}
+
+	handler := NewSyncUserHandler(uid, db, config)
+	resp := request("GET", syncurl(uid, "info/configuration"), nil, handler)
+
+	assert.Equal(http.StatusOK, resp.Code)
+	assert.Equal("application/json", resp.Header().Get("Content-Type"))
+
+	jdata := make(map[string]int)
+	if err := json.Unmarshal(resp.Body.Bytes(), &jdata); assert.NoError(err) {
+
+		if val, ok := jdata["max_post_bytes"]; assert.True(ok, "max_post_bytes") {
+			assert.Equal(val, config.MaxPOSTBytes)
+		}
+		if val, ok := jdata["max_post_records"]; assert.True(ok, "max_post_records") {
+			assert.Equal(val, config.MaxPOSTRecords)
+		}
+		if val, ok := jdata["max_total_bytes"]; assert.True(ok, "max_total_bytes") {
+			assert.Equal(val, config.MaxTotalBytes)
+		}
+		if val, ok := jdata["max_total_records"]; assert.True(ok, "max_total_records") {
+			assert.Equal(val, config.MaxTotalRecords)
+		}
+	}
+}
+
+// TestSyncUserHandlerPOST tests that POSTs behave correctly
+func TestSyncUserHandlerPOST(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	uid := "123456"
+
+	db, _ := syncstorage.NewDB(":memory:")
+	handler := NewSyncUserHandler(uid, db, nil)
+	url := syncurl(uid, "storage/bookmarks")
+
+	{
+		header := make(http.Header)
+		header.Add("Content-Type", "application/octet-stream")
+
+		resp := requestheaders("POST", url, nil, header, handler)
+		if !assert.Equal(http.StatusUnsupportedMediaType, resp.Code) {
+			return
+		}
+	}
+
+	// Make sure INSERT works first
+	body := bytes.NewBufferString(`[
+		{"id":"bso1", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+		{"id":"bso2", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+		{"id":"bso3", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
+	]`)
+
+	// POST new data
+	header := make(http.Header)
+	header.Add("Content-Type", "application/json")
+	cId, _ := db.GetCollectionId("bookmarks")
+
+	{
+		resp := requestheaders("POST", url, body, header, handler)
+
+		assert.Equal(http.StatusOK, resp.Code)
+
+		var results PostResults
+		jsbody := resp.Body.Bytes()
+		err := json.Unmarshal(jsbody, &results)
+		if !assert.NoError(err) {
+			return
+		}
+
+		assert.Len(results.Success, 3)
+		assert.Len(results.Failed, 0)
+
+		// verify it made it into the db ok
+		for _, bId := range []string{"bso1", "bso2", "bso3"} {
+			bso, _ := db.GetBSO(cId, bId)
+			assert.Equal("initial payload", bso.Payload)
+			assert.Equal(1, bso.SortIndex)
+		}
+	}
+
+	{
+		// Test that updates work
+		body = bytes.NewBufferString(`[
+			{"id":"bso1", "sortindex": 2},
+			{"id":"bso2", "payload": "updated payload"},
+			{"id":"bso3", "payload": "updated payload", "sortindex":3}
+		]`)
+
+		resp := requestheaders("POST", url, body, header, handler)
+		assert.Equal(http.StatusOK, resp.Code)
+
+		bso, _ := db.GetBSO(cId, "bso1")
+		assert.Equal("initial payload", bso.Payload) // stayed the same
+		assert.Equal(2, bso.SortIndex)               // it updated
+
+		bso, _ = db.GetBSO(cId, "bso2")
+		assert.Equal("updated payload", bso.Payload) // updated
+		assert.Equal(1, bso.SortIndex)               // same
+
+		bso, _ = db.GetBSO(cId, "bso3")
+		assert.Equal(bso.Payload, "updated payload") // updated
+		assert.Equal(3, bso.SortIndex)               // updated
+	}
+}
+
+// TestSyncUserHandlerPOSTBatch tests that a batch can be created, appended to and commited
+func TestSyncUserHandlerPOSTBatch(t *testing.T) {
+
+	assert := assert.New(t)
+
+	bodyCreate := bytes.NewBufferString(`[
+		{"id":"bso0", "payload": "bso0"},
+		{"id":"bso1", "payload": "bso1"}
+	]`)
+	bodyAppend := bytes.NewBufferString(`[
+		{"id":"bso2", "payload": "bso2"},
+		{"id":"bso3", "payload": "bso3"}
+	]`)
+	bodyCommit := bytes.NewBufferString(`[
+		{"id":"bso4", "payload": "bso4"},
+		{"id":"bso5", "payload": "bso5"}
+	]`)
+
+	uid := "123456"
+
+	db, _ := syncstorage.NewDB(":memory:")
+	handler := NewSyncUserHandler(uid, db, nil)
+	collection := "testcol"
+
+	url := syncurl(uid, "storage/"+collection)
+	header := make(http.Header)
+	header.Add("Content-Type", "application/json")
+
+	respCreate := requestheaders("POST", url+"?batch=true", bodyCreate, header, handler)
+	if !assert.Equal(http.StatusOK, respCreate.Code, respCreate.Body.String()) {
+		return
+	}
+	var createResults PostResults
+	if err := json.Unmarshal(respCreate.Body.Bytes(), &createResults); !assert.NoError(err) {
+		return
+	}
+
+	assert.Equal(1, createResults.Batch) // clean db, always gets 1
+	batchIdString := strconv.Itoa(createResults.Batch)
+
+	respAppend := requestheaders("POST", url+"?batch="+batchIdString, bodyAppend, header, handler)
+	assert.Equal(http.StatusOK, respAppend.Code, respAppend.Body.String())
+
+	respCommit := requestheaders("POST", url+"?commit=1&batch="+batchIdString, bodyCommit, header, handler)
+	assert.Equal(http.StatusOK, respCommit.Code, respCommit.Body.String())
+
+	cId, _ := db.GetCollectionId(collection)
+	for bIdNum := 0; bIdNum <= 5; bIdNum++ {
+		bId := "bso" + strconv.Itoa(bIdNum)
+		_, err := db.GetBSO(cId, bId)
+		assert.NoError(err, "Could not find bso: %s", bId)
+	}
+
+	// make sure the batch is no longer in the db
+	_, errMissing := db.BatchLoad(createResults.Batch, cId)
+	assert.Equal(syncstorage.ErrBatchNotFound, errMissing)
 }

--- a/web/weaveHandler.go
+++ b/web/weaveHandler.go
@@ -15,17 +15,24 @@ const (
 	// old legacy stuff, used to keep compatibility with python/old clients
 	// https://github.com/mozilla-services/server-syncstorage/blob/fd3c8b90278cb9944cb224964af6e6dae19c9263/syncstorage/tweens.py#L17-L21
 
-	WEAVE_UNKNOWN_ERROR  = "0"
-	WEAVE_ILLEGAL_METH   = "1"  // Illegal method/protocol
-	WEAVE_MALFORMED_JSON = "6"  // Json parse failure
-	WEAVE_INVALID_WBO    = "8"  // Invalid Weave Basic Object
-	WEAVE_OVER_QUOTA     = "14" // User over quota
+	WEAVE_UNKNOWN_ERROR       = "0"
+	WEAVE_ILLEGAL_METH        = "1"  // Illegal method/protocol
+	WEAVE_MALFORMED_JSON      = "6"  // Json parse failure
+	WEAVE_INVALID_WBO         = "8"  // Invalid Weave Basic Object
+	WEAVE_OVER_QUOTA          = "14" // User over quota
+	WEAVE_SIZE_LIMIT_EXCEEDED = "17" // Batch X-Weave-* headers too large
 )
 
 func WeaveInvalidWBOError(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	w.Write([]byte(WEAVE_INVALID_WBO))
+}
+
+func WeaveSizeLimitExceeded(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	w.Write([]byte(WEAVE_SIZE_LIMIT_EXCEEDED))
 }
 
 // WeaveHandler is a convenient and messy place to capture


### PR DESCRIPTION
- Fixes #92, add support for batch/atomic commit functionality
- Add `Batches` table to sqlite schema
- Add Configurable sync limits to support new `/info/configuration` endpoint and `X-Weave-*` headers
- See: [mozilla-services/server-syncstorage/pull/36](https://github.com/mozilla-services/server-syncstorage/pull/36) for python implementation. This implementation must pass that one's functional tests.

**Implementation notes:**
- One DB record per batch. 
- BSOs are kept as newline separated JSON blobs. 
- When BSOs are added to a batch, they are simply appended to the end of text blob in the batch db record
- Committing takes all the combined JSON and runs them like a giant classic POST. This reuses the same logic and is a single transaction. 
