### PR TITLE
add ability to disable HTTP logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The server has a few knobs that can be tweaked.
 | `SECRETS` | Comma separated list of shared secrets. Secrets are tried in order and allows for secret rotation without downtime. |
 | `LOG_LEVEL`| Log verbosity, allowed: `fatal`,`error`,`warn`,`debug`,`info`|
 | `LOG_MOZLOG` | Can be `true` or `false`. Outputs logs in [mozlog](https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md) format. |
+| `LOG_DISABLE_HTTP` | Can be `true` or `false`. Disables logging of HTTP requests. |
 | `HOSTNAME` | Set a hostname value for mozlog output |
 
 ## Advanced Configuration

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,9 @@ type LogConfig struct {
 
 	// use mozlog format
 	Mozlog bool `envconfig:"default=false"`
+
+	// Disable HTTP Logging
+	DisableHTTP bool `envconfig:"default=false"`
 }
 
 type PoolConfig struct {
@@ -47,6 +50,10 @@ var (
 	Secrets     []string
 	Pool        *PoolConfig
 	EnablePprof bool
+
+	Limit *UserHandlerConfig
+
+	DisableHTTPLogs bool
 )
 
 func init() {

--- a/config/config.go
+++ b/config/config.go
@@ -51,8 +51,6 @@ var (
 	Pool        *PoolConfig
 	EnablePprof bool
 
-	Limit *UserHandlerConfig
-
 	DisableHTTPLogs bool
 )
 

--- a/server.go
+++ b/server.go
@@ -47,7 +47,9 @@ func main() {
 	router = web.NewInfoHandler(router)
 
 	// Log all the things
-	router = web.NewLogHandler(router)
+	if config.Log.DisableHTTP != true {
+		router = web.NewLogHandler(router)
+	}
 
 	if config.EnablePprof {
 		log.Info("Enabling pprof profile at /debug/pprof/")


### PR DESCRIPTION
Add ability to disable HTTP request logging. Often, these logs are duplicated with the web server, upstream proxy logs. Also helps when debugging.
