### PR TITLE
syncstorage/DB.DeleteCollection retains collections in Collections table

### DIFF
--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -316,14 +316,8 @@ func (d *DB) DeleteCollection(cId int) (err error) {
 	}
 
 	dmlB := "DELETE FROM BSO WHERE CollectionId=?"
-	dmlC := "DELETE FROM Collections WHERE Id=?"
 
 	if _, err := tx.Exec(dmlB, cId); err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	if _, err := tx.Exec(dmlC, cId); err != nil {
 		tx.Rollback()
 		return err
 	}

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -591,17 +591,12 @@ func TestDeleteCollection(t *testing.T) {
 
 		// make sure it was deleted
 		if assert.Nil(err) {
-
 			// make sure BSOs are deleted
 			for _, bId := range bIds {
 				b, err := db.GetBSO(cId, bId)
 				assert.Exactly(ErrNotFound, err)
 				assert.Nil(b)
 			}
-
-			id, err := db.GetCollectionId(cName)
-			assert.Equal(0, id)
-			assert.Exactly(ErrNotFound, err)
 		}
 	}
 }


### PR DESCRIPTION
- this makes more sense since collections id:1..id:11 and id:99 were getting
  deleted in the wild (stage testing)
- there's no need to delete collection records. Keeping them around is
  fine
