### PR TITLE
Change to use go1.7 new context library

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,10 +7,26 @@ machine:
     A: "$GWS/src/github.com/$CIRCLE_PROJECT_USERNAME"
     B: "$A/$CIRCLE_PROJECT_REPONAME"
 
+    # Use to install Custom golang
+    GODIST: "go1.7.linux-amd64.tar.gz"
+    GODIST_HASH: "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95"
+
   services:
     - docker
 
+  # install custom golang
+  post:
+    - mkdir -p download
+    - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
+    # verify it
+    - echo "$GODIST_HASH  download/$GODIST" | sha256sum -c
+    - sudo rm -rf /usr/local/go
+    - sudo tar -C /usr/local -xzf download/$GODIST
+
 dependencies:
+  cache_directories:
+    - ~/download
+
   override:
     # ported from https://discuss.circleci.com/t/overriding-go-inference-in-the-dependencies-phase/660
     # put the source in $GOPATH

--- a/token/token.go
+++ b/token/token.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strconv"
 	"time"
 
 	"golang.org/x/crypto/hkdf"
@@ -35,6 +36,10 @@ type TokenPayload struct {
 	Uid     uint64  `json:"uid"`
 	Node    string  `json:"node"`
 	Expires float64 `json:"expires"`
+}
+
+func (t *TokenPayload) UidString() string {
+	return strconv.FormatUint(t.Uid, 10)
 }
 
 type Token struct {

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -10,6 +10,8 @@ package token
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_NewToken(t *testing.T) {
@@ -52,8 +54,6 @@ func Test_ParseToken(t *testing.T) {
 	if len(generatedToken.DerivedSecret) == 0 {
 		t.Error("generatedToken.DerivedSecret is empty")
 	}
-
-	//
 
 	parsedToken, err := ParseToken([]byte("thisisasecret"), generatedToken.Token)
 	if err != nil {
@@ -105,4 +105,14 @@ func Test_TokenExpired(t *testing.T) {
 		}
 	}
 
+}
+
+func TestTokenPayload(t *testing.T) {
+	payload := TokenPayload{
+		Uid:     1234,
+		Node:    "http://node.mozilla.org",
+		Expires: 1452807004.454294,
+	}
+
+	assert.Equal(t, "1234", payload.UidString())
 }

--- a/web/session.go
+++ b/web/session.go
@@ -1,0 +1,24 @@
+package web
+
+import (
+	"context"
+
+	"github.com/mozilla-services/go-syncstorage/token"
+)
+
+type sessionKey int
+
+var sKey sessionKey = 0
+
+type Session struct {
+	Token token.TokenPayload
+}
+
+func NewSessionContext(ctx context.Context, ses *Session) context.Context {
+	return context.WithValue(ctx, sKey, ses)
+}
+
+func SessionFromContext(ctx context.Context) (*Session, bool) {
+	s, ok := ctx.Value(sKey).(*Session)
+	return s, ok
+}

--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -74,7 +74,10 @@ func (s *SyncPoolHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		err     error
 	)
 
-	uid = extractUID(req.URL.Path)
+	if session, ok := SessionFromContext(req.Context()); ok {
+		uid = session.Token.UidString()
+	}
+
 	if uid == "" {
 		http.Error(w, "Invalid sync path", http.StatusBadRequest)
 		return


### PR DESCRIPTION
This PR uses go 1.7's new [context](https://tip.golang.org/pkg/context/) library for passing the uid between http handlers. The design I took was to create a `web.Session` struct, which currently only holds a `token.TokenPayload`. 

Previously the UID was extracted out of the URL and the `web.SyncPoolHandler` trusted that it was verified by `web.HawkHandler` somewhere before. In this new design the UID is extracted from the token payload itself. This should improve security as well making it more idiomatic go 1.7 :).

@oremj @jvehent can you R? 

Also, I tweaked the circle.yml to install go 1.7. I'll probably keep this so I won't be tied to circle's release schedule. :)
