### PR TITLE
fix null encoding for Failed key in POST collections

### DIFF
--- a/web/misc.go
+++ b/web/misc.go
@@ -52,7 +52,7 @@ func (p *PostResults) MarshalJSON() ([]byte, error) {
 	buf.WriteString(syncstorage.ModifiedToString(p.Modified))
 	buf.WriteString(",")
 	if len(p.Success) == 0 {
-		buf.WriteString(`"success":null`)
+		buf.WriteString(`"success":[]`)
 	} else {
 		buf.WriteString(`"success":`)
 		data, err := json.Marshal(p.Success)
@@ -67,7 +67,7 @@ func (p *PostResults) MarshalJSON() ([]byte, error) {
 
 	buf.WriteString(",")
 	if len(p.Failed) == 0 {
-		buf.WriteString(`"failed":null`)
+		buf.WriteString(`"failed":{}`)
 	} else {
 		buf.WriteString(`"failed":`)
 		data, err := json.Marshal(p.Failed)

--- a/web/syncUserHandler_misc_test.go
+++ b/web/syncUserHandler_misc_test.go
@@ -1,0 +1,42 @@
+package web
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostResultJSONMarshaller(t *testing.T) {
+	assert := assert.New(t)
+
+	{ // make sure the zero values encode correctly
+		x := &PostResults{}
+		b, err := json.Marshal(x)
+		if !assert.NoError(err) {
+			return
+		}
+
+		assert.Equal(`{"modified":0.00,"success":[],"failed":{}}`, string(b))
+	}
+
+	{ // make sure non zero values encode correctly
+		x := &PostResults{
+			Batch:    1,
+			Modified: 12345678,
+			Success:  []string{"bso0", "bso1"},
+			Failed: map[string][]string{
+				"bso2": {"a", "b", "c"},
+				"bso3": {"d", "e", "f"},
+			},
+		}
+
+		b, err := json.Marshal(x)
+		if !assert.NoError(err) {
+			return
+		}
+
+		assert.Equal(`{"modified":12345.68,"success":["bso0","bso1"],"failed":{"bso2":["a","b","c"],"bso3":["d","e","f"]},"batch":1}`, string(b))
+
+	}
+}


### PR DESCRIPTION
After deploying a box into production and putting @jvehent and @mostlygeek on it we discovered a bug. From the sync dumps: 

```
1471907263290   Sync.Collection DEBUG   POST success 200 https://sync-368-us-west-2.sync.services.mozilla.com/1.5/<redacted>/storage/bookmarks
1471907263302   Sync.Status DEBUG   Status for engine bookmarks: error.engine.reason.unknown_fail
1471907263302   Sync.Status DEBUG   Status.service: error.sync.failed_partial => error.sync.failed_partial
1471907263302   Sync.ErrorHandler   DEBUG   bookmarks failed: TypeError: can't convert null to object (resource://services-sync/engines.js:1470:26) JS Stack trace: SyncEngine.prototype._uploadOutgoing/handleResponse@engines.js:1470:26 < flush@record.js:703:5 < enqueue@record.js:686:7 < SyncEngine.prototype._uploadOutgoing@engines.js:1502:11 < SyncEngine.prototype._sync@engines.js:1557:7 < wrappedSync@bookmarks.js:229:11 < _sync@bookmarks.js:226:5 < WrappedNotify@util.js:146:21 < Engine.prototype.sync@engines.js:670:5 < _syncEngine@enginesync.js:213:7 < sync@enginesync.js:163:15 < onNotify@service.js:1262:7 < WrappedNotify@util.js:146:21 < WrappedLock@util.js:101:16 < _lockedSync@service.js:1252:12 < sync/<@service.js:1244:14 < WrappedCatch@util.js:75:16 < sync@service.js:1232:5
```

On a successful POST to `storage/bookmarks`, the `Failed` key in the response was null. This apparently blows up Desktop firefox. The cause of this is due to the custom JSON encoder for the POST result payload. 

It has been changed from `failed:null` to `failed:{}`. Also the `success` key was also updated to create an empty array. 

Tests were also added to prevent any regressions in the future.
