### PR TITLE
Improve checking of client's Content-Type, ref issue #108

### DIFF
--- a/web/misc.go
+++ b/web/misc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -215,7 +216,7 @@ func InternalError(w http.ResponseWriter, r *http.Request, err error) {
 		"path":   r.URL.Path,
 	}).Errorf("HTTP Error: %s", err.Error())
 
-	switch w.Header().Get("Content-Type") {
+	switch getMediaType(w.Header().Get("Content-Type")) {
 	case "application/newlines":
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
@@ -380,4 +381,12 @@ func sendRequestProblem(w http.ResponseWriter, req *http.Request, responseCode i
 	}).Warning("HTTP Request Problem")
 
 	JSONError(w, reason.Error(), responseCode)
+}
+
+// getMediaType extracts the mediatype portion from the http request header Content-Type
+// it returns a blank string on error. It also discards the paramters. This is enough
+// for working with sync clients
+func getMediaType(contentType string) (mediatype string) {
+	mediatype, _, _ = mime.ParseMediaType(contentType)
+	return
 }

--- a/web/misc_test.go
+++ b/web/misc_test.go
@@ -104,7 +104,14 @@ func TestJSONError(t *testing.T) {
 		assert.Equal(http.StatusNotAcceptable, w.Code)
 		assert.Equal(`{"err":" this \" is a \" tough\n\t\t  string for json. ''\n\t\t"}`, w.Body.String())
 	}
+}
 
+func TestGetMediaType(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("text/plain", getMediaType("text/plain"))
+	assert.Equal("application/json", getMediaType("application/json"))
+	assert.Equal("application/json", getMediaType("application/json; a=b ; c=d"))
+	assert.Equal("", getMediaType("this is invalid:"))
 }
 
 func BenchmarkNewLine(b *testing.B) {

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -506,7 +506,7 @@ func (s *SyncUserHandler) hCollectionGET(w http.ResponseWriter, r *http.Request)
 
 func (s *SyncUserHandler) hCollectionPOST(w http.ResponseWriter, r *http.Request) {
 	// accept text/plain from old (broken) clients
-	ct := r.Header.Get("Content-Type")
+	ct := getMediaType(r.Header.Get("Content-Type"))
 	if ct != "application/json" && ct != "text/plain" && ct != "application/newlines" {
 		sendRequestProblem(w, r, http.StatusUnsupportedMediaType, errors.Errorf("Not acceptable Content-Type: %s", ct))
 		return
@@ -890,7 +890,7 @@ func (s *SyncUserHandler) hBsoPUT(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// accept text/plain from old (broken) clients
-	ct := r.Header.Get("Content-Type")
+	ct := getMediaType(r.Header.Get("Content-Type"))
 	if ct != "application/json" && ct != "text/plain" && ct != "application/newlines" {
 		sendRequestProblem(w, r, http.StatusUnsupportedMediaType, errors.Errorf("Not acceptable Content-Type: %s", ct))
 		return

--- a/web/syncUserHandler_misc.go
+++ b/web/syncUserHandler_misc.go
@@ -27,7 +27,7 @@ func RequestToPostBSOInput(r *http.Request) (
 	// a list of all the raw json encoded BSOs
 	var raw []json.RawMessage
 
-	if ct := r.Header.Get("Content-Type"); ct == "application/json" || ct == "text/plain" {
+	if ct := getMediaType(r.Header.Get("Content-Type")); ct == "application/json" || ct == "text/plain" {
 		decoder := json.NewDecoder(r.Body)
 		err := decoder.Decode(&raw)
 		if err != nil {

--- a/web/syncUserHandler_test.go
+++ b/web/syncUserHandler_test.go
@@ -146,6 +146,20 @@ func TestSyncUserHandlerPOST(t *testing.T) {
 		assert.Equal(bso.Payload, "updated payload") // updated
 		assert.Equal(3, bso.SortIndex)               // updated
 	}
+
+	{ // ref: issue #108 - handling of Content-Type like application/json;charset=utf-8
+		body := bytes.NewBufferString(`[
+			{"id":"bsoa", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			{"id":"bsob", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			{"id":"bsoc", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
+		]`)
+
+		// POST new data
+		header := make(http.Header)
+		header.Add("Content-Type", "application/json;charset=utf-8")
+		resp := requestheaders("POST", url, body, header, handler)
+		assert.Equal(http.StatusOK, resp.Code)
+	}
 }
 
 // TestSyncUserHandlerPOSTBatch tests that a batch can be created, appended to and commited

--- a/web/weaveHandler.go
+++ b/web/weaveHandler.go
@@ -106,7 +106,7 @@ func (w *weaveWriter) WriteHeader(statusCode int) {
 	// Matches python server's behaviour: https://git.io/vVvTt
 	// for passing test_that_404_responses_have_a_json_body python
 	// functional test
-	if statusCode == http.StatusNotFound && w.Header().Get("Content-Type") != "application/json" {
+	if statusCode == http.StatusNotFound && getMediaType(w.Header().Get("Content-Type")) != "application/json" {
 		w.w.Header().Set("Content-Type", "application/json")
 		w.w.WriteHeader(statusCode)
 		w.w.Write([]byte(WEAVE_UNKNOWN_ERROR))


### PR DESCRIPTION
- Properly extract the media-type portion of a Content-Type header
- add tests for web/getMediaType()
