### PR TITLE
Fix two issues from #108

### DIFF
--- a/web/misc.go
+++ b/web/misc.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -215,7 +216,7 @@ func InternalError(w http.ResponseWriter, r *http.Request, err error) {
 		"path":   r.URL.Path,
 	}).Errorf("HTTP Error: %s", err.Error())
 
-	switch w.Header().Get("Content-Type") {
+	switch getMediaType(w.Header().Get("Content-Type")) {
 	case "application/newlines":
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(err.Error()))
@@ -380,4 +381,12 @@ func sendRequestProblem(w http.ResponseWriter, req *http.Request, responseCode i
 	}).Warning("HTTP Request Problem")
 
 	JSONError(w, reason.Error(), responseCode)
+}
+
+// getMediaType extracts the mediatype portion from the http request header Content-Type
+// it returns a blank string on error. It also discards the paramters. This is enough
+// for working with sync clients
+func getMediaType(contentType string) (mediatype string) {
+	mediatype, _, _ = mime.ParseMediaType(contentType)
+	return
 }

--- a/web/misc.go
+++ b/web/misc.go
@@ -364,6 +364,11 @@ func OKResponse(w http.ResponseWriter, s string) {
 // and responds with a json payload of the error. Client side these
 // are usually invisible so this helps with debugging
 func sendRequestProblem(w http.ResponseWriter, req *http.Request, responseCode int, reason error) {
+	logRequestProblem(req, responseCode, reason)
+	JSONError(w, reason.Error(), responseCode)
+}
+
+func logRequestProblem(req *http.Request, responseCode int, reason error) {
 	var causeMessage string
 	if cause := errors.Cause(reason); cause != nil && cause != reason {
 		causeMessage = fmt.Sprintf("%v", cause)
@@ -379,8 +384,6 @@ func sendRequestProblem(w http.ResponseWriter, req *http.Request, responseCode i
 		"error":     reason.Error(),
 		"cause":     causeMessage,
 	}).Warning("HTTP Request Problem")
-
-	JSONError(w, reason.Error(), responseCode)
 }
 
 // getMediaType extracts the mediatype portion from the http request header Content-Type

--- a/web/misc_test.go
+++ b/web/misc_test.go
@@ -104,7 +104,14 @@ func TestJSONError(t *testing.T) {
 		assert.Equal(http.StatusNotAcceptable, w.Code)
 		assert.Equal(`{"err":" this \" is a \" tough\n\t\t  string for json. ''\n\t\t"}`, w.Body.String())
 	}
+}
 
+func TestGetMediaType(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("text/plain", getMediaType("text/plain"))
+	assert.Equal("application/json", getMediaType("application/json"))
+	assert.Equal("application/json", getMediaType("application/json; a=b ; c=d"))
+	assert.Equal("", getMediaType("this is invalid:"))
 }
 
 func BenchmarkNewLine(b *testing.B) {

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -506,7 +506,7 @@ func (s *SyncUserHandler) hCollectionGET(w http.ResponseWriter, r *http.Request)
 
 func (s *SyncUserHandler) hCollectionPOST(w http.ResponseWriter, r *http.Request) {
 	// accept text/plain from old (broken) clients
-	ct := r.Header.Get("Content-Type")
+	ct := getMediaType(r.Header.Get("Content-Type"))
 	if ct != "application/json" && ct != "text/plain" && ct != "application/newlines" {
 		sendRequestProblem(w, r, http.StatusUnsupportedMediaType, errors.Errorf("Not acceptable Content-Type: %s", ct))
 		return
@@ -890,7 +890,7 @@ func (s *SyncUserHandler) hBsoPUT(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// accept text/plain from old (broken) clients
-	ct := r.Header.Get("Content-Type")
+	ct := getMediaType(r.Header.Get("Content-Type"))
 	if ct != "application/json" && ct != "text/plain" && ct != "application/newlines" {
 		sendRequestProblem(w, r, http.StatusUnsupportedMediaType, errors.Errorf("Not acceptable Content-Type: %s", ct))
 		return

--- a/web/syncUserHandler_misc.go
+++ b/web/syncUserHandler_misc.go
@@ -27,7 +27,7 @@ func RequestToPostBSOInput(r *http.Request) (
 	// a list of all the raw json encoded BSOs
 	var raw []json.RawMessage
 
-	if ct := r.Header.Get("Content-Type"); ct == "application/json" || ct == "text/plain" {
+	if ct := getMediaType(r.Header.Get("Content-Type")); ct == "application/json" || ct == "text/plain" {
 		decoder := json.NewDecoder(r.Body)
 		err := decoder.Decode(&raw)
 		if err != nil {

--- a/web/syncUserHandler_misc_test.go
+++ b/web/syncUserHandler_misc_test.go
@@ -1,9 +1,15 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/mozilla-services/go-syncstorage/syncstorage"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,5 +44,70 @@ func TestPostResultJSONMarshaller(t *testing.T) {
 
 		assert.Equal(`{"modified":12345.68,"success":["bso0","bso1"],"failed":{"bso2":["a","b","c"],"bso3":["d","e","f"]},"batch":1}`, string(b))
 
+	}
+}
+
+func TestReadNewlineJSON(t *testing.T) {
+	assert := assert.New(t)
+	numBSOs := 10
+
+	buf := new(bytes.Buffer)
+	// make some very large new line separated BSOs to test with
+
+	// create a worst case huge json payload
+	size := 256 * 1024 // 256KB = max size
+	payload := strings.Repeat("a", size)
+
+	for i := 0; i < numBSOs; i++ {
+		buf.WriteString(`{"ttl":1234567,"sortindex":1,"id":"`)
+		buf.WriteString(strconv.Itoa(i))
+
+		buf.WriteString(`","payload":"`)
+		buf.WriteString(payload)
+
+		buf.WriteString(`"}`)
+		buf.WriteByte('\n')
+	}
+
+	rawJSON := ReadNewlineJSON(buf)
+	if !assert.Equal(numBSOs, len(rawJSON)) {
+		return
+	}
+
+	// make sure each entry is valid json
+	for i, rawBSO := range rawJSON {
+		var b syncstorage.PutBSOInput
+		parseErr := parseIntoBSO(rawBSO, &b)
+		if !assert.Nil(parseErr, "invalid json for id:"+strconv.Itoa(i)) {
+			fmt.Println(string(rawBSO))
+			return
+		}
+	}
+}
+
+func BenchmarkReadNewlineJSON(b *testing.B) {
+	numBSOs := 10
+	buf := new(bytes.Buffer)
+
+	// create larger than average BSO payload
+	size := 16 * 1024
+	payload := strings.Repeat("a", size)
+
+	for i := 0; i < numBSOs; i++ {
+		buf.WriteString(`{"ttl":1234567,"sortindex":1,"id":"`)
+		buf.WriteString(strconv.Itoa(i))
+
+		buf.WriteString(`","payload":"`)
+		buf.WriteString(payload)
+
+		buf.WriteString(`"}`)
+		buf.WriteByte('\n')
+	}
+
+	// make a ReadSeeker out of it
+	reader := bytes.NewReader(buf.Bytes())
+	for i := 0; i < b.N; i++ {
+		ReadNewlineJSON(reader)
+		reader.Seek(0, io.SeekStart)
 	}
 }

--- a/web/syncUserHandler_test.go
+++ b/web/syncUserHandler_test.go
@@ -146,6 +146,20 @@ func TestSyncUserHandlerPOST(t *testing.T) {
 		assert.Equal(bso.Payload, "updated payload") // updated
 		assert.Equal(3, bso.SortIndex)               // updated
 	}
+
+	{ // ref: issue #108 - handling of Content-Type like application/json;charset=utf-8
+		body := bytes.NewBufferString(`[
+			{"id":"bsoa", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			{"id":"bsob", "payload": "initial payload", "sortindex": 1, "ttl": 2100000},
+			{"id":"bsoc", "payload": "initial payload", "sortindex": 1, "ttl": 2100000}
+		]`)
+
+		// POST new data
+		header := make(http.Header)
+		header.Add("Content-Type", "application/json;charset=utf-8")
+		resp := requestheaders("POST", url, body, header, handler)
+		assert.Equal(http.StatusOK, resp.Code)
+	}
 }
 
 // TestSyncUserHandlerPOSTBatch tests that a batch can be created, appended to and commited

--- a/web/weaveHandler.go
+++ b/web/weaveHandler.go
@@ -106,7 +106,7 @@ func (w *weaveWriter) WriteHeader(statusCode int) {
 	// Matches python server's behaviour: https://git.io/vVvTt
 	// for passing test_that_404_responses_have_a_json_body python
 	// functional test
-	if statusCode == http.StatusNotFound && w.Header().Get("Content-Type") != "application/json" {
+	if statusCode == http.StatusNotFound && getMediaType(w.Header().Get("Content-Type")) != "application/json" {
 		w.w.Header().Set("Content-Type", "application/json")
 		w.w.WriteHeader(statusCode)
 		w.w.Write([]byte(WEAVE_UNKNOWN_ERROR))

--- a/web/weaveHandler.go
+++ b/web/weaveHandler.go
@@ -23,13 +23,15 @@ const (
 	WEAVE_SIZE_LIMIT_EXCEEDED = "17" // Batch X-Weave-* headers too large
 )
 
-func WeaveInvalidWBOError(w http.ResponseWriter, r *http.Request) {
+func WeaveInvalidWBOError(w http.ResponseWriter, r *http.Request, reason error) {
+	logRequestProblem(r, http.StatusBadRequest, reason)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	w.Write([]byte(WEAVE_INVALID_WBO))
 }
 
-func WeaveSizeLimitExceeded(w http.ResponseWriter, r *http.Request) {
+func WeaveSizeLimitExceeded(w http.ResponseWriter, r *http.Request, reason error) {
+	logRequestProblem(r, http.StatusBadRequest, reason)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	w.Write([]byte(WEAVE_SIZE_LIMIT_EXCEEDED))


### PR DESCRIPTION
Found two large bugs in handling requests from iOS: 
1. `web/ReadNewlineJSON` has a bunch of bugs: 
   - it returned bad json raw data because of improper use of `scanner.Bytes()`. It didn't make a copy of the output. Since slices are references, the underlying data changed and inconsistent data came out
   - the scanner's default buffer, 64KB was too small. Increased to 257KB will fit all valid BSO payloads. The buffer being too small resulted in not actually finding the individual BSOs
2. Insufficient handling of values in `Content-Type` headers. We really only need the "mediatype" not all the params. Now it is extracted and checked correctly 

Notably, I took some time to optimize ReadNewlineJSON. By using a `sync.Pool` for its scanner's buffer it reduces memory allocation overhead and increases performance. The benchcmp output: 

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkReadNewlineJSON-8     112636        95069         -15.60%

benchmark                      old allocs     new allocs     delta
BenchmarkReadNewlineJSON-8     26             26             +0.00%

benchmark                      old bytes     new bytes     delta
BenchmarkReadNewlineJSON-8     603912        334257        -44.65%
```
