### PR TITLE
Change batch id to be a string when being sent to the client

### DIFF
--- a/web/misc.go
+++ b/web/misc.go
@@ -38,7 +38,7 @@ func extractUID(path string) string {
 // used to massage post results into JSON
 // the client expects
 type PostResults struct {
-	Batch    int
+	Batch    string
 	Modified int
 	Success  []string
 	Failed   map[string][]string
@@ -81,13 +81,13 @@ func (p *PostResults) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	if p.Batch > 0 {
-		buf.WriteString(`,"batch":`)
-		buf.WriteString(strconv.Itoa(p.Batch))
+	if p.Batch != "" {
+		buf.WriteString(`,"batch":"`)
+		buf.WriteString(p.Batch)
+		buf.WriteString(`"`)
 	}
 
 	buf.WriteString("}")
-
 	return buf.Bytes(), nil
 }
 
@@ -95,7 +95,7 @@ func (p *PostResults) MarshalJSON() ([]byte, error) {
 func (p *PostResults) UnmarshalJSON(data []byte) error {
 	var tmp struct {
 		Modified float64
-		Batch    int
+		Batch    string
 		Success  []string
 		Failed   map[string][]string
 	}
@@ -213,7 +213,7 @@ func InternalError(w http.ResponseWriter, r *http.Request, err error) {
 	log.WithFields(log.Fields{
 		"cause":  errors.Cause(err).Error(),
 		"method": r.Method,
-		"path":   r.URL.Path,
+		"path":   r.URL.EscapedPath() + "?" + r.URL.RawQuery,
 	}).Errorf("HTTP Error: %s", err.Error())
 
 	switch getMediaType(w.Header().Get("Content-Type")) {

--- a/web/syncUserHandler_misc.go
+++ b/web/syncUserHandler_misc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -116,4 +117,22 @@ func GetBatchIdAndCommit(r *http.Request) (batchFound bool, batchId string, batc
 	_, batchCommit = r.URL.Query()["commit"]
 
 	return
+}
+
+// Why the conversion from a prefixed string to an int and back?
+// This is match the python implementation for a batchId that is
+// guaranteed to be treated like a string.
+// ref: https://github.com/mozilla-services/server-syncstorage/commit/3694262132ec47f60e0ce9c9e4645f23969ece13
+
+// batchIdInt converts the string batchid back into an integer
+func batchIdInt(batchId string) (int, error) {
+	if len(batchId) < 2 {
+		return 0, errors.New("Batch ID too short")
+	}
+	return strconv.Atoi(batchId[1:])
+}
+
+// batchIdString converts the internal batchId int into a string
+func batchIdString(batchId int) string {
+	return "b" + strconv.Itoa(batchId)
 }

--- a/web/syncUserHandler_misc_test.go
+++ b/web/syncUserHandler_misc_test.go
@@ -28,7 +28,7 @@ func TestPostResultJSONMarshaller(t *testing.T) {
 
 	{ // make sure non zero values encode correctly
 		x := &PostResults{
-			Batch:    1,
+			Batch:    batchIdString(1),
 			Modified: 12345678,
 			Success:  []string{"bso0", "bso1"},
 			Failed: map[string][]string{
@@ -42,7 +42,7 @@ func TestPostResultJSONMarshaller(t *testing.T) {
 			return
 		}
 
-		assert.Equal(`{"modified":12345.68,"success":["bso0","bso1"],"failed":{"bso2":["a","b","c"],"bso3":["d","e","f"]},"batch":1}`, string(b))
+		assert.Equal(`{"modified":12345.68,"success":["bso0","bso1"],"failed":{"bso2":["a","b","c"],"bso3":["d","e","f"]},"batch":"b1"}`, string(b))
 
 	}
 }
@@ -110,4 +110,25 @@ func BenchmarkReadNewlineJSON(b *testing.B) {
 		ReadNewlineJSON(reader)
 		reader.Seek(0, io.SeekStart)
 	}
+}
+
+func TestBatchIdInt(t *testing.T) {
+	assert := assert.New(t)
+
+	_, err := batchIdInt("1")
+	assert.NotNil(err)
+
+	n, err := batchIdInt("abc")
+	assert.Equal(0, n)
+	assert.NotNil(err)
+
+	n, err = batchIdInt("a1")
+	assert.Equal(1, n)
+	assert.Nil(err)
+}
+
+func TestBatchIdString(t *testing.T) {
+	assert.Equal(t, "b-1", batchIdString(-1))
+	assert.Equal(t, "b0", batchIdString(0))
+	assert.Equal(t, "b123", batchIdString(123))
 }


### PR DESCRIPTION
This keeps spec with the python implementation.
See: https://git.io/v6Nqa
- updated tests 
- improve error reporting for `InternalError` 
- Change `Batch` to be a string in the returned JSON Payload
