### PR TITLE
use sendRequestProblem to log more request issues

### DIFF
--- a/web/misc.go
+++ b/web/misc.go
@@ -332,8 +332,9 @@ func AcceptHeaderOk(w http.ResponseWriter, r *http.Request) bool {
 		return true
 	}
 
-	if strings.Contains(accept, "application/json") ||
-		strings.Contains(accept, "application/newlines") {
+	mediatype := getMediaType(accept)
+
+	if mediatype == "application/json" || mediatype == "application/newlines" {
 		return true
 	}
 
@@ -345,9 +346,8 @@ func AcceptHeaderOk(w http.ResponseWriter, r *http.Request) bool {
 	}
 
 	// everything else is an error
-	http.Error(w,
-		http.StatusText(http.StatusNotAcceptable),
-		http.StatusNotAcceptable)
+	sendRequestProblem(w, r, http.StatusNotAcceptable,
+		errors.Errorf("Unsupported Accept header: %s", accept))
 
 	return false
 }

--- a/web/stoppableHandler.go
+++ b/web/stoppableHandler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 	"sync"
 )
@@ -32,5 +33,5 @@ func (s *StoppableHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	w.Header().Set("Retry-After", retryAfter)
-	http.Error(w, "Service Unvailable", http.StatusServiceUnavailable)
+	sendRequestProblem(w, req, http.StatusServiceUnavailable, errors.New("HTTP handler stopped"))
 }

--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -86,7 +86,7 @@ func (s *SyncPoolHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if uid == "" {
-		http.Error(w, "Invalid sync path", http.StatusBadRequest)
+		sendRequestProblem(w, req, http.StatusBadRequest, errors.New("Pool: No UID"))
 		return
 	}
 
@@ -106,7 +106,8 @@ func (s *SyncPoolHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 				if i == conflictAttempts {
 					w.Header().Add("Retry-After", strconv.Itoa(60))
-					http.Error(w, "DB Busy", http.StatusConflict)
+					sendRequestProblem(w, req, http.StatusConflict,
+						errors.New("DB pool too busy"))
 					return
 				}
 


### PR DESCRIPTION
Replace all http.Error and JSONError() calls with sendRequestProblem() so
warnings with helpful information is logged.
