### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,4 @@ A linux binary is also available as build artifacts from [Circle CI](https://cir
 
 # License
 
-See [LICENSE](LICENSE.txt).
+See [LICENSE](LICENCE.txt).


### PR DESCRIPTION
This PR fixes a faulty link inside `README.md`.

Where it previously stated `LICENSE.txt`, it should've linked to `LICENCE.txt`, since that's the correct name of the file.
