### PR TITLE
Move max payload size and get limit from db to web layer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,13 +24,14 @@ type LogConfig struct {
 
 // configures limits for web/SyncUserHandler
 type UserHandlerConfig struct {
-	MaxRequestBytes int `envconfig:"default=0"`
-	MaxBSOGetLimit  int `envconfig:"default=0"`
-	MaxPOSTRecords  int `envconfig:"default=0"`
-	MaxPOSTBytes    int `envconfig:"default=0"`
-	MaxTotalRecords int `envconfig:"default=0"`
-	MaxTotalBytes   int `envconfig:"default=0"`
-	MaxBatchTTL     int `envconfig:"default=0"`
+	MaxRequestBytes       int `envconfig:"default=2097152"`
+	MaxBSOGetLimit        int `envconfig:"default=1000"`
+	MaxPOSTRecords        int `envconfig:"default=100"`
+	MaxPOSTBytes          int `envconfig:"default=2097152"`
+	MaxTotalRecords       int `envconfig:"default=1000"`
+	MaxTotalBytes         int `envconfig:"default=20971520"`
+	MaxBatchTTL           int `envconfig:"default=7200"`   // 2 hours
+	MaxRecordPayloadBytes int `envconfig:"default=262144"` // 256KB
 }
 
 type PoolConfig struct {
@@ -118,23 +119,26 @@ func init() {
 		Config.Pool.Num = runtime.NumCPU()
 	}
 
-	if Config.Limit.MaxBSOGetLimit < 0 {
-		log.Fatal("LIMIT_MAX_BSO_GET_LIMIT must be >= 0")
+	if Config.Limit.MaxBSOGetLimit < 1 {
+		log.Fatal("LIMIT_MAX_BSO_GET_LIMIT must be >= 1")
 	}
-	if Config.Limit.MaxPOSTRecords < 0 {
-		log.Fatal("LIMIT_MAX_POST_RECORDS must be >= 0")
+	if Config.Limit.MaxPOSTRecords < 1 {
+		log.Fatal("LIMIT_MAX_POST_RECORDS must be >= 1")
 	}
-	if Config.Limit.MaxPOSTBytes < 0 {
-		log.Fatal("LIMIT_MAX_MAX_POST_BYTES must be >= 0")
+	if Config.Limit.MaxPOSTBytes < 1 {
+		log.Fatal("LIMIT_MAX_MAX_POST_BYTES must be >= 1")
 	}
-	if Config.Limit.MaxTotalRecords < 0 {
-		log.Fatal("LIMIT_MAX_TOTAL_RECORDS must be >= 0")
+	if Config.Limit.MaxTotalRecords < 1 {
+		log.Fatal("LIMIT_MAX_TOTAL_RECORDS must be >= 1")
 	}
-	if Config.Limit.MaxTotalBytes < 0 {
-		log.Fatal("LIMIT_MAX_TOTAL_BYTES must be >= 0")
+	if Config.Limit.MaxTotalBytes < 1 {
+		log.Fatal("LIMIT_MAX_TOTAL_BYTES must be >= 1")
 	}
-	if Config.Limit.MaxBatchTTL < 0 {
-		log.Fatal("LIMIT_MAX_BATCH_TTL must be > 0")
+	if Config.Limit.MaxBatchTTL < 10 {
+		log.Fatal("LIMIT_MAX_BATCH_TTL must be >= 10")
+	}
+	if Config.Limit.MaxRecordPayloadBytes < 1 {
+		log.Fatal("LIMIT_MAX_RECORD_PAYLOAD_BYTES must be >= 1")
 	}
 
 	Hostname = Config.Hostname

--- a/server.go
+++ b/server.go
@@ -34,27 +34,14 @@ func main() {
 	var router http.Handler
 
 	syncLimitConfig := web.NewDefaultSyncUserHandlerConfig()
-	if config.Limit.MaxRequestBytes != 0 {
-		syncLimitConfig.MaxRequestBytes = config.Limit.MaxRequestBytes
-	}
-	if config.Limit.MaxBSOGetLimit != 0 {
-		syncLimitConfig.MaxBSOGetLimit = config.Limit.MaxBSOGetLimit
-	}
-	if config.Limit.MaxPOSTRecords != 0 {
-		syncLimitConfig.MaxPOSTRecords = config.Limit.MaxPOSTRecords
-	}
-	if config.Limit.MaxPOSTBytes != 0 {
-		syncLimitConfig.MaxPOSTBytes = config.Limit.MaxPOSTBytes
-	}
-	if config.Limit.MaxTotalBytes != 0 {
-		syncLimitConfig.MaxTotalBytes = config.Limit.MaxTotalBytes
-	}
-	if config.Limit.MaxTotalRecords != 0 {
-		syncLimitConfig.MaxTotalRecords = config.Limit.MaxTotalRecords
-	}
-	if config.Limit.MaxBatchTTL != 0 {
-		syncLimitConfig.MaxBatchTTL = config.Limit.MaxBatchTTL * 1000
-	}
+	syncLimitConfig.MaxRequestBytes = config.Limit.MaxRequestBytes
+	syncLimitConfig.MaxBSOGetLimit = config.Limit.MaxBSOGetLimit
+	syncLimitConfig.MaxPOSTRecords = config.Limit.MaxPOSTRecords
+	syncLimitConfig.MaxPOSTBytes = config.Limit.MaxPOSTBytes
+	syncLimitConfig.MaxTotalBytes = config.Limit.MaxTotalBytes
+	syncLimitConfig.MaxTotalRecords = config.Limit.MaxTotalRecords
+	syncLimitConfig.MaxBatchTTL = config.Limit.MaxBatchTTL * 1000
+	syncLimitConfig.MaxRecordPayloadBytes = config.Limit.MaxRecordPayloadBytes
 
 	// The base functionality is the sync 1.5 api + legacy weave hacks
 	poolHandler := web.NewSyncPoolHandler(&web.SyncPoolConfig{
@@ -104,17 +91,18 @@ func main() {
 	}
 
 	log.WithFields(log.Fields{
-		"addr":                    listenOn,
-		"PID":                     os.Getpid(),
-		"POOL_NUM":                config.Pool.Num,
-		"POOL_MAX_SIZE":           config.Pool.MaxSize,
-		"LIMIT_MAX_BSO_GET_LIMIT": syncLimitConfig.MaxBSOGetLimit,
-		"LIMIT_MAX_POST_RECORDS":  syncLimitConfig.MaxPOSTRecords,
-		"LIMIT_MAX_POST_BYTES":    syncLimitConfig.MaxPOSTBytes,
-		"LIMIT_MAX_TOTAL_RECORDS": syncLimitConfig.MaxTotalRecords,
-		"LIMIT_MAX_TOTAL_BYTES":   syncLimitConfig.MaxTotalBytes,
-		"LIMIT_MAX_REQUEST_BYTES": syncLimitConfig.MaxRequestBytes,
-		"LIMIT_MAX_BATCH_TTL":     fmt.Sprintf("%d seconds", syncLimitConfig.MaxBatchTTL/1000),
+		"addr":                           listenOn,
+		"PID":                            os.Getpid(),
+		"POOL_NUM":                       config.Pool.Num,
+		"POOL_MAX_SIZE":                  config.Pool.MaxSize,
+		"LIMIT_MAX_BSO_GET_LIMIT":        syncLimitConfig.MaxBSOGetLimit,
+		"LIMIT_MAX_POST_RECORDS":         syncLimitConfig.MaxPOSTRecords,
+		"LIMIT_MAX_POST_BYTES":           syncLimitConfig.MaxPOSTBytes,
+		"LIMIT_MAX_TOTAL_RECORDS":        syncLimitConfig.MaxTotalRecords,
+		"LIMIT_MAX_TOTAL_BYTES":          syncLimitConfig.MaxTotalBytes,
+		"LIMIT_MAX_REQUEST_BYTES":        syncLimitConfig.MaxRequestBytes,
+		"LIMIT_MAX_BATCH_TTL":            fmt.Sprintf("%d seconds", syncLimitConfig.MaxBatchTTL/1000),
+		"LIMIT_MAX_RECORD_PAYLOAD_BYTES": syncLimitConfig.MaxRecordPayloadBytes,
 	}).Info("HTTP Listening at " + listenOn)
 
 	err := httpdown.ListenAndServe(server, hd)

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -32,8 +32,6 @@ var (
 	ErrInvalidLimit  = errors.New("Invalid LIMIT")
 	ErrInvalidOffset = errors.New("Invalid OFFSET")
 	ErrInvalidNewer  = errors.New("Invalid NEWER than")
-
-	ErrPayloadTooBig = errors.New("BSO payload too big")
 )
 
 // dbTx allows passing of sql.DB or sql.Tx
@@ -51,14 +49,8 @@ const (
 	SORT_OLDEST
 	SORT_INDEX
 
-	// absolute maximum records getBSOs can return
-	LIMIT_MAX = 1000
-
 	// Keep BSO for 1 year
 	DEFAULT_BSO_TTL = 365 * 24 * 60 * 60 * 1000
-
-	// max BSO size
-	MAX_BSO_PAYLOAD_SIZE = 1024 * 256
 )
 
 type CollectionInfo struct {
@@ -725,11 +717,6 @@ func (d *DB) putBSO(tx dbTx,
 		return
 	}
 
-	if payload != nil && len(*payload) >= (MAX_BSO_PAYLOAD_SIZE) {
-		err = ErrPayloadTooBig
-		return
-	}
-
 	exists, err := d.bsoExists(tx, cId, bId)
 	if err != nil {
 		return
@@ -832,10 +819,6 @@ func (d *DB) getBSOs(
 		orderBy = "ORDER BY Modified DESC "
 	} else if sort == SORT_OLDEST {
 		orderBy = "ORDER BY Modified ASC "
-	}
-
-	if limit == 0 || limit > LIMIT_MAX {
-		limit = LIMIT_MAX
 	}
 
 	limitStmt := "LIMIT ?"


### PR DESCRIPTION
A [change to the python server](https://github.com/mozilla-services/server-syncstorage/pull/36/commits/a71150e00fea32f550a1bf479a7335ccd24c9839) spurred this change.  It also triggered a bunch of refactoring to move all limits to the web layer.

Changes: 
- Move the max POST/PUT BSO limit size out of the syncstorage package
  and into the web package
- make the max BSO payload size configurable
- Improve and add tests for refactor
