### PR TITLE
fix so all HTTP errors go through sendRequestProblem()

### DIFF
--- a/web/misc.go
+++ b/web/misc.go
@@ -204,29 +204,20 @@ func extractBsoId(r *http.Request) (bId string, ok bool) {
 func extractBsoIdFail(w http.ResponseWriter, r *http.Request) (bId string, ok bool) {
 	bId, ok = extractBsoId(r)
 	if !ok {
-		JSONError(w, "Invalid bso ID", http.StatusNotFound)
+		sendRequestProblem(w, r, http.StatusNotFound,
+			errors.New("Could not extract bso id from URL"))
 	}
 	return
 }
 
 // InternalError produces an HTTP 500 error, basically means a bug in the system
 func InternalError(w http.ResponseWriter, r *http.Request, err error) {
-
 	log.WithFields(log.Fields{
 		"cause":  errors.Cause(err).Error(),
 		"method": r.Method,
 		"path":   r.URL.EscapedPath() + "?" + r.URL.RawQuery,
 	}).Errorf("HTTP Error: %s", err.Error())
-
-	switch getMediaType(w.Header().Get("Content-Type")) {
-	case "application/newlines":
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
-	case "":
-		fallthrough
-	case "application/json":
-		JSONError(w, err.Error(), http.StatusInternalServerError)
-	}
+	sendRequestProblem(w, r, http.StatusInternalServerError, err)
 }
 
 // NewLine prints out new line \n separated JSON objects instead of a

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -970,7 +970,7 @@ func (s *SyncUserHandler) hBsoPUT(w http.ResponseWriter, r *http.Request) {
 	modified, err = s.db.PutBSO(cId, bId, bso.Payload, bso.SortIndex, bso.TTL)
 
 	if err != nil {
-		JSONError(w, err.Error(), http.StatusBadRequest)
+		sendRequestProblem(w, r, http.StatusBadRequest, err)
 		return
 	}
 	m := syncstorage.ModifiedToString(modified)
@@ -994,7 +994,7 @@ func (s *SyncUserHandler) hBsoDELETE(w http.ResponseWriter, r *http.Request) {
 
 	cId, err = s.getcid(r, false)
 	if err == syncstorage.ErrNotFound {
-		JSONError(w, "Collection Not Found", http.StatusNotFound)
+		sendRequestProblem(w, r, http.StatusNotAcceptable, errors.Wrap(err, "Could not find collection"))
 		return
 	}
 
@@ -1003,7 +1003,7 @@ func (s *SyncUserHandler) hBsoDELETE(w http.ResponseWriter, r *http.Request) {
 	bso, err := s.db.GetBSO(cId, bId)
 	if err != nil {
 		if err == syncstorage.ErrNotFound {
-			JSONError(w, fmt.Sprintf("BSO id: %s Not Found", bId), http.StatusNotFound)
+			sendRequestProblem(w, r, http.StatusNotFound, errors.Errorf("BSO id: %s Not Found", bId))
 		} else {
 			InternalError(w, r, err)
 		}


### PR DESCRIPTION
There were a few places where JSONError was still getting called directly. Fixed now.
