### PR TITLE
make sqlite cache_size pragma configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ When a pool reaches `POOL_SIZE` number of open files it will close the least rec
 
 Tweaking these values from default won't provide significant performance gains in production. However, a `POOL_NUM=1` and `POOL_SIZE=1` is useful for testing the overhead of opening and closing databases files.
 
+### Sqlite3 Tweaks 
+
+| Env. Var | Info |
+|---|---|
+| `SQLITE3_CACHE_SIZE` | Sets sqlite's internal cache size for each open DB. Busy servers open/close the db files often so a smaller cache size may be more efficient. Follows the [PRAGMA cache_size](https://www.sqlite.org/pragma.html#pragma_cache_size) rules. Positive integers are number of pages to cache, negative numbers are KB of RAM to use for cache. Default 0 (no cache)|
+
+
 ## Data Storage
 
 When deploying choose the EXT4 filesystem. EXT4 is an extent based filesystem and may help improve performance for magnetic storage media.

--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,10 @@ type PoolConfig struct {
 	MaxSize int `envconfig:"default=25"`
 }
 
+type SqliteConfig struct {
+	CacheSize int `envconfig:"default=0"`
+}
+
 var Config struct {
 	Log      *LogConfig
 	Hostname string `envconfig:"optional"`
@@ -47,6 +51,7 @@ var Config struct {
 	Secrets  []string
 	DataDir  string
 	Pool     *PoolConfig
+	Sqlite   *SqliteConfig
 
 	// Enable the pprof web endpoint /debug/pprof/
 	EnablePprof bool `envconfig:"default=false"`
@@ -65,6 +70,7 @@ var (
 	DataDir     string
 	Secrets     []string
 	Pool        *PoolConfig
+	Sqlite      *SqliteConfig
 	EnablePprof bool
 
 	Limit *UserHandlerConfig
@@ -150,4 +156,5 @@ func init() {
 	Pool = Config.Pool
 	EnablePprof = Config.EnablePprof
 	Limit = Config.Limit
+	Sqlite = Config.Sqlite
 }

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/facebookgo/httpdown"
 
 	"github.com/mozilla-services/go-syncstorage/config"
+	"github.com/mozilla-services/go-syncstorage/syncstorage"
 	"github.com/mozilla-services/go-syncstorage/web"
 )
 
@@ -48,6 +49,7 @@ func main() {
 		Basepath:    config.DataDir,
 		NumPools:    config.Pool.Num,
 		MaxPoolSize: config.Pool.MaxSize,
+		DBConfig:    &syncstorage.Config{config.Sqlite.CacheSize},
 	}, syncLimitConfig)
 	router = web.NewWeaveHandler(poolHandler)
 
@@ -103,6 +105,7 @@ func main() {
 		"LIMIT_MAX_REQUEST_BYTES":        syncLimitConfig.MaxRequestBytes,
 		"LIMIT_MAX_BATCH_TTL":            fmt.Sprintf("%d seconds", syncLimitConfig.MaxBatchTTL/1000),
 		"LIMIT_MAX_RECORD_PAYLOAD_BYTES": syncLimitConfig.MaxRecordPayloadBytes,
+		"SQLITE3_CACHE_SIZE":             config.Sqlite.CacheSize,
 	}).Info("HTTP Listening at " + listenOn)
 
 	err := httpdown.ListenAndServe(server, hd)

--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/mozilla-services/go-syncstorage/syncstorage"
 	"github.com/pkg/errors"
 )
 
@@ -31,6 +32,8 @@ type SyncPoolConfig struct {
 	NumPools    int
 	TTL         time.Duration
 	MaxPoolSize int
+
+	DBConfig *syncstorage.Config
 }
 
 func NewDefaultSyncPoolConfig(basepath string) *SyncPoolConfig {
@@ -39,13 +42,17 @@ func NewDefaultSyncPoolConfig(basepath string) *SyncPoolConfig {
 		NumPools:    1,
 		TTL:         5 * time.Minute,
 		MaxPoolSize: 100,
+		DBConfig:    &syncstorage.Config{CacheSize: 0},
 	}
 }
 
 func NewSyncPoolHandler(config *SyncPoolConfig, userHandlerConfig *SyncUserHandlerConfig) *SyncPoolHandler {
 	pools := make([]*handlerPool, config.NumPools, config.NumPools)
 	for i := 0; i < config.NumPools; i++ {
-		pools[i] = newHandlerPool(config.Basepath, config.MaxPoolSize)
+		pools[i] = newHandlerPool(
+			config.Basepath,
+			config.MaxPoolSize,
+			config.DBConfig)
 	}
 
 	if userHandlerConfig == nil {

--- a/web/syncPoolHandler_elements.go
+++ b/web/syncPoolHandler_elements.go
@@ -45,9 +45,12 @@ type handlerPool struct {
 
 	// the max size of the pool
 	maxPoolSize int
+
+	// the DB Configuration
+	dbConfig *syncstorage.Config
 }
 
-func newHandlerPool(basepath string, maxPoolSize int) *handlerPool {
+func newHandlerPool(basepath string, maxPoolSize int, dbConfig *syncstorage.Config) *handlerPool {
 
 	var path []string
 
@@ -75,6 +78,7 @@ func newHandlerPool(basepath string, maxPoolSize int) *handlerPool {
 		lru:         list.New(),
 		lrumap:      make(map[string]*list.Element),
 		maxPoolSize: maxPoolSize,
+		dbConfig:    dbConfig,
 	}
 
 	return pool
@@ -140,7 +144,7 @@ func (p *handlerPool) getElement(uid string) (*poolElement, error) {
 			p.Lock()
 		}
 
-		db, err := syncstorage.NewDB(dbFile)
+		db, err := syncstorage.NewDB(dbFile, p.dbConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "Could not create DB")
 		}

--- a/web/syncUserHandler_test.go
+++ b/web/syncUserHandler_test.go
@@ -15,7 +15,7 @@ import (
 func TestSyncUserHandlerStopPurgeClose(t *testing.T) {
 	assert := assert.New(t)
 	uid := uniqueUID()
-	db, _ := syncstorage.NewDB(":memory:")
+	db, _ := syncstorage.NewDB(":memory:", nil)
 	handler := NewSyncUserHandler(uid, db, nil)
 
 	handler.StopHTTP()
@@ -31,7 +31,7 @@ func TestSyncUserHandlerInfoConfiguration(t *testing.T) {
 
 	assert := assert.New(t)
 	uid := uniqueUID()
-	db, _ := syncstorage.NewDB(":memory:")
+	db, _ := syncstorage.NewDB(":memory:", nil)
 
 	// make sure values propagate from the configuration
 	config := &SyncUserHandlerConfig{
@@ -79,7 +79,7 @@ func TestSyncUserHandlerPOST(t *testing.T) {
 
 	uid := "123456"
 
-	db, _ := syncstorage.NewDB(":memory:")
+	db, _ := syncstorage.NewDB(":memory:", nil)
 	handler := NewSyncUserHandler(uid, db, nil)
 	url := syncurl(uid, "storage/bookmarks")
 
@@ -221,7 +221,7 @@ func TestSyncUserHandlerPOSTBatch(t *testing.T) {
 	header.Add("Content-Type", "application/json")
 
 	{ // test common flow
-		db, _ := syncstorage.NewDB(":memory:")
+		db, _ := syncstorage.NewDB(":memory:", nil)
 		handler := NewSyncUserHandler(uid, db, nil)
 
 		respCreate := requestheaders("POST", url+"?batch=true", bodyCreate, header, handler)
@@ -256,7 +256,7 @@ func TestSyncUserHandlerPOSTBatch(t *testing.T) {
 	}
 
 	{ // test commit=1&batch=true
-		db, _ := syncstorage.NewDB(":memory:")
+		db, _ := syncstorage.NewDB(":memory:", nil)
 		handler := NewSyncUserHandler(uid, db, nil)
 
 		bodyCreate := bytes.NewBufferString(`[
@@ -272,7 +272,7 @@ func TestSyncUserHandlerPOSTBatch(t *testing.T) {
 	}
 
 	{ // test batch=true and an empty commit
-		db, _ := syncstorage.NewDB(":memory:")
+		db, _ := syncstorage.NewDB(":memory:", nil)
 		handler := NewSyncUserHandler(uid, db, nil)
 
 		bodyCreate := bytes.NewBufferString(`[
@@ -308,7 +308,7 @@ func TestSyncUserHandlerPUT(t *testing.T) {
 
 	uid := "123456"
 
-	db, _ := syncstorage.NewDB(":memory:")
+	db, _ := syncstorage.NewDB(":memory:", nil)
 	handler := NewSyncUserHandler(uid, db, nil)
 	url := syncurl(uid, "storage/bookmarks/bso0")
 	header := make(http.Header)


### PR DESCRIPTION
The compiled in default is `-2000` which is 2000 KB (2MB) per sqlite database. The theory is that the sqlite cache does very little in practice because: 
- on a busy server with many users DBs are open/closed too frequently for the cache to matter
- the kernel's page cache already has the data in memory so double caching it is wasteful

This PR allows the cache_size to be configurable to tweak for production workloads
