### PR TITLE
fix bug where info/collections has wrong timestamps

### DIFF
--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -275,7 +275,17 @@ func (s *SyncUserHandler) hInfoCollections(w http.ResponseWriter, r *http.Reques
 
 		m := syncstorage.ModifiedToString(modified)
 		w.Header().Set("X-Last-Modified", m)
-		JsonNewline(w, r, info)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "{")
+		num := len(info)
+		for name, modified := range info {
+			fmt.Fprintf(w, `"%s":%s`, name, syncstorage.ModifiedToString(modified))
+			num--
+			if num != 0 {
+				fmt.Fprint(w, ",")
+			}
+		}
+		fmt.Fprint(w, "}")
 	}
 }
 


### PR DESCRIPTION
This is a bad bug. `db.InfoCollections()` returns timestamps as milliseconds since the epoch as `int`. Passing it directly to `JsonNewline()` means the values are always off by about 1000 since it should be in sync 1.5's timestamp format. 
