### PR TITLE
Add web/CacheHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The server has a few knobs that can be tweaked.
 | `LIMIT_MAX_TOTAL_BYTES` |  Maximum total size of a POST batch job. Default: 26,214,400 (20MB). |
 | `LIMIT_MAX_TOTAL_RECORDS` | Maximum total BSOs in a POST batch job. Default 1000. |
 | `LIMIT_MAX_BATCH_TTL` | Maximum TTL for a batch to remain uncommitted in seconds. Default 7200 (2 hours). |
+| `INFO_CACHE_SIZE` | Cache size in MB for `<uid>/info/collections` and `<uid>/info/configuration`. Default 0 (disabled) | 
 
 ## Advanced Configuration
 Things that probably shouldn't be touched:

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,9 @@ var Config struct {
 	// SyncUserHandler limits / configuration
 	// available as LIMIT_x
 	Limit *UserHandlerConfig
+
+	// cache size in MB for /info/collections cache
+	InfoCacheSize int `envconfig:"default=0"`
 }
 
 // so we can use config.Port and not config.Config.Port
@@ -76,6 +79,8 @@ var (
 	Limit *UserHandlerConfig
 
 	DisableHTTPLogs bool
+
+	InfoCacheSize int
 )
 
 func init() {
@@ -147,6 +152,10 @@ func init() {
 		log.Fatal("LIMIT_MAX_RECORD_PAYLOAD_BYTES must be >= 1")
 	}
 
+	if Config.InfoCacheSize < 0 {
+		log.Fatal("INFO_CACHE_SIZE must be >= 0")
+	}
+
 	Hostname = Config.Hostname
 	Log = Config.Log
 	Host = Config.Host
@@ -157,4 +166,5 @@ func init() {
 	EnablePprof = Config.EnablePprof
 	Limit = Config.Limit
 	Sqlite = Config.Sqlite
+	InfoCacheSize = Config.InfoCacheSize
 }

--- a/web/cacheHandler.go
+++ b/web/cacheHandler.go
@@ -1,0 +1,186 @@
+package web
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/allegro/bigcache"
+)
+
+var (
+	infoCollectionsRoute   *regexp.Regexp
+	infoConfigurationRoute *regexp.Regexp
+
+	DefaultCacheHandlerConfig = CacheConfig{
+		MaxCacheSize: 256,
+	}
+)
+
+func init() {
+	infoCollectionsRoute = regexp.MustCompile(`^/1\.5/([0-9]+)/info/collections$`)
+	infoConfigurationRoute = regexp.MustCompile(`^/1\.5/([0-9]+)/info/configuration$`)
+}
+
+type CacheConfig struct {
+	MaxCacheSize int // megabytes
+}
+
+// CacheHandler contains logic for caching and speeding up
+// requests that do not need to go to disk. Endpoints such as
+// info/collections and info/configuration can be cached and
+// served out of RAM.
+type CacheHandler struct {
+	handler http.Handler
+
+	cache *bigcache.BigCache
+}
+
+func NewCacheHandler(handler http.Handler, cacheConfig CacheConfig) *CacheHandler {
+	bcConfig := bigcache.DefaultConfig(time.Hour)
+	bcConfig.HardMaxCacheSize = cacheConfig.MaxCacheSize
+
+	// use to calculate initial size
+	bcConfig.MaxEntrySize = 256 // bytes, should fit almost all responses
+	bcConfig.LifeWindow = 2000  // number of unique users seen in time.Hour
+
+	cache, err := bigcache.NewBigCache(bcConfig)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"err": err.Error(),
+		}).Panic("Could not create Cache bigcache")
+	}
+
+	return &CacheHandler{
+		handler: handler,
+		cache:   cache,
+	}
+}
+
+func (s *CacheHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var uid string
+
+	if session, ok := SessionFromContext(req.Context()); ok {
+		uid = session.Token.UidString()
+	} else {
+		sendRequestProblem(w, req, http.StatusBadRequest, errors.New("CacheHandler no UID"))
+		return
+	}
+
+	if req.Method == "GET" && infoCollectionsRoute.MatchString(req.URL.Path) { // info/collections
+		s.infoCollection(uid, w, req)
+	} else if req.Method == "GET" && infoConfigurationRoute.MatchString(req.URL.Path) { // info/configuration
+		s.infoConfiguration(uid, w, req)
+	} else {
+		// clear the cache for the  user
+		if req.Method == "POST" || req.Method == "PUT" || req.Method == "DELETE" {
+			if log.GetLevel() == log.DebugLevel {
+				log.WithFields(log.Fields{
+					"uid": uid,
+				}).Debug("CacheHandler clear")
+			}
+			s.cache.Set(lastModifiedKey(uid), []byte{})
+			s.cache.Set(uid, []byte{})
+		}
+		s.handler.ServeHTTP(w, req)
+		return
+	}
+}
+
+func lastModifiedKey(uid string) string {
+	return ("l" + uid)
+}
+
+// infoCollection caches a user's info/collection data. It will clear
+// the cached data if a POST, PUT, or DELETE method is done
+func (s *CacheHandler) infoCollection(uid string, w http.ResponseWriter, req *http.Request) {
+
+	lmkey := lastModifiedKey(uid)
+
+	if lm, err := s.cache.Get(lmkey); err == nil && len(lm) > 0 {
+		modified, _ := ConvertTimestamp(string(lm))
+		if sentNotModified(w, req, modified) {
+			return
+		}
+
+		if data, err := s.cache.Get(uid); err == nil && len(data) > 0 {
+			// add the the X-Last-Modified header
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Last-Modified", string(lm))
+			io.Copy(w, bytes.NewReader(data))
+			return
+		}
+	}
+
+	// fill the cache ...
+	cacheWriter := newCacheResponseWriter(w)
+	s.handler.ServeHTTP(cacheWriter, req)
+
+	// cache the results for next time if successful response
+	if cacheWriter.code == http.StatusOK {
+		s.cache.Set(uid, cacheWriter.Bytes())
+		s.cache.Set(lmkey, []byte(w.Header().Get("X-Last-Modified")))
+		if log.GetLevel() == log.DebugLevel {
+			log.WithFields(log.Fields{
+				"uid":      uid,
+				"modified": w.Header().Get("X-Last-Modified"),
+			}).Debug("CacheHandler Set info/collections")
+		}
+	}
+}
+
+func (s *CacheHandler) infoConfiguration(uid string, w http.ResponseWriter, req *http.Request) {
+	if data, err := s.cache.Get("config"); err == nil && len(data) > 0 {
+		// add the the X-Last-Modified header
+		w.Header().Set("Content-Type", "application/json")
+		io.Copy(w, bytes.NewReader(data))
+		return
+	}
+
+	// fill the cache ...
+	cacheWriter := newCacheResponseWriter(w)
+	s.handler.ServeHTTP(cacheWriter, req)
+
+	// cache the results for next time if successful response
+	if cacheWriter.code == http.StatusOK {
+		s.cache.Set("config", cacheWriter.Bytes())
+	}
+}
+
+type cacheResponseWriter struct {
+	w    http.ResponseWriter /// original wrapped ResponseWriter
+	buf  *bytes.Buffer
+	mw   io.Writer
+	code int
+}
+
+func (c *cacheResponseWriter) Header() http.Header {
+	return c.w.Header()
+}
+
+func (c *cacheResponseWriter) WriteHeader(i int) {
+	c.code = i
+	c.w.WriteHeader(i)
+}
+
+func (c *cacheResponseWriter) Write(b []byte) (int, error) {
+	return c.mw.Write(b)
+}
+
+func (c *cacheResponseWriter) Bytes() []byte {
+	return c.buf.Bytes()
+}
+
+func newCacheResponseWriter(w http.ResponseWriter) *cacheResponseWriter {
+	buffer := new(bytes.Buffer)
+	return &cacheResponseWriter{
+		w:    w,
+		buf:  buffer,
+		mw:   io.MultiWriter(w, buffer),
+		code: http.StatusOK,
+	}
+}

--- a/web/cacheHandler.go
+++ b/web/cacheHandler.go
@@ -130,7 +130,6 @@ func (s *CacheHandler) infoCollection(uid string, w http.ResponseWriter, req *ht
 
 	// cache the results for next time if successful response
 	if cacheWriter.code == http.StatusOK {
-
 		data := make([]byte, cacheWriter.Len()+lastModifiedBytes)
 
 		copy(data, w.Header().Get("X-Last-Modified"))

--- a/web/cacheHandler_test.go
+++ b/web/cacheHandler_test.go
@@ -120,7 +120,7 @@ func TestCacheHandlerInfoCollections(t *testing.T) {
 		}
 		for _, cName := range collections {
 			cId, _ := db.GetCollectionId(cName)
-			db.TouchCollection(cId, cId*1000) // turn the cId into milliseconds
+			db.TouchCollection(cId, syncstorage.Now()+cId) // turn the cId into milliseconds
 		}
 
 		resp := request("GET", syncurl(uid, "info/collections"), nil, handler)

--- a/web/cacheHandler_test.go
+++ b/web/cacheHandler_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mozilla-services/go-syncstorage/syncstorage"
+	"github.com/mozilla-services/go-syncstorage/token"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -162,7 +163,16 @@ func BenchmarkCacheHandler(b *testing.B) {
 		db.TouchCollection(cId, cId*1000) // turn the cId into milliseconds
 	}
 
+	req, err := http.NewRequest("GET", "/storage/12345/info/collections", nil)
+	req.Header.Set("Accept", "application/json")
+	if err != nil {
+		panic(err)
+	}
+	session := &Session{Token: token.TokenPayload{Uid: 12345}}
+	reqCtx := req.WithContext(NewSessionContext(req.Context(), session))
+
 	for i := 0; i < b.N; i++ {
-		request("GET", syncurl(uid, "info/collections"), nil, handler)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, reqCtx)
 	}
 }

--- a/web/cacheHandler_test.go
+++ b/web/cacheHandler_test.go
@@ -1,0 +1,168 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mozilla-services/go-syncstorage/syncstorage"
+	"github.com/stretchr/testify/assert"
+)
+
+// generates a unique response each time so caching can be tested
+var cacheMockHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+	resp := struct {
+		Type  string
+		Value string
+	}{"OK", syncstorage.ModifiedToString(syncstorage.Now())}
+
+	w.Header().Set("X-Last-Modified", resp.Value)
+
+	if infoCollectionsRoute.MatchString(req.URL.Path) {
+		resp.Type = "info/collections"
+		JSON(w, req, resp)
+	} else if infoConfigurationRoute.MatchString(req.URL.Path) {
+		resp.Type = "info/configuration"
+		JSON(w, req, resp)
+	} else {
+		JSON(w, req, resp)
+	}
+})
+
+func TestCacheHandlerInfoCollections(t *testing.T) {
+	assert := assert.New(t)
+	handler := NewCacheHandler(cacheMockHandler, DefaultCacheHandlerConfig)
+	url := syncurl(uniqueUID(), "info/collections?version=1.5") // sometimes we see queries in the requests
+
+	{
+		// basic test to make sure data is what's expected and caching works
+		resp := request("GET", url, nil, handler)
+		assert.Equal(http.StatusOK, resp.Code)
+		assert.True(strings.Contains(resp.Body.String(), `"Type":"info/collections"`))
+		assert.Equal("application/json", resp.Header().Get("Content-Type"))
+
+		resp2 := request("GET", url, nil, handler)
+		assert.Equal(http.StatusOK, resp2.Code)
+		assert.Equal(resp.Body.String(), resp2.Body.String(), "Expected cached value")
+		assert.Equal(resp.Header().Get("X-Last-Modified"), resp2.Header().Get("X-Last-Modified"))
+	}
+
+	// test POST, PUT, DELETE invalidates the cache
+	{
+		var last *httptest.ResponseRecorder
+		for _, method := range []string{"POST", "PUT", "DELETE"} {
+
+			if last == nil {
+				last = request("GET", url, nil, handler)
+			}
+
+			// ensures things stay the same
+			resp := request("GET", url, nil, handler)
+			assert.Equal(http.StatusOK, resp.Code)
+			assert.Equal(last.Body.String(), resp.Body.String())
+			assert.Equal(last.Header().Get("X-Last-Modified"), resp.Header().Get("X-Last-Modified"))
+
+			// swap it
+			last = resp
+
+			// this should clear the cache
+			// compensate for sync's time format..
+			time.Sleep(10 * time.Millisecond)
+
+			request(method, url, nil, handler)
+
+			_ = method
+
+			//// make sure things are changed
+			resp = request("GET", url, nil, handler)
+			assert.Equal(http.StatusOK, resp.Code)
+			assert.NotEqual(last.Body.String(), resp.Body.String(), "Should have changed")
+			assert.NotEqual(last.Header().Get("X-Last-Modified"), resp.Header().Get("X-Last-Modified"))
+
+			last = resp
+		}
+	}
+
+	// test that different uids get different values
+	{
+		resp1a := request("GET", syncurl("123", "info/collections"), nil, handler)
+		resp1b := request("GET", syncurl("123", "info/collections"), nil, handler)
+
+		time.Sleep(10 * time.Millisecond) /// SYNNNC!! .. so awesome timestamps
+
+		resp2b := request("GET", syncurl("456", "info/collections"), nil, handler)
+		resp2a := request("GET", syncurl("456", "info/collections"), nil, handler)
+
+		assert.Equal(http.StatusOK, resp1a.Code)
+		assert.Equal(http.StatusOK, resp1b.Code)
+		assert.Equal(http.StatusOK, resp2a.Code)
+		assert.Equal(http.StatusOK, resp2b.Code)
+
+		// cacheing works
+		assert.Equal(resp1a.Body.String(), resp1b.Body.String())
+		assert.Equal(resp2a.Body.String(), resp2b.Body.String())
+
+		// no conflicts
+		assert.NotEqual(resp1a.Body.String(), resp2a.Body.String())
+	}
+
+	{ // test with a real SyncUserHandler
+		uid := "123456"
+		db, _ := syncstorage.NewDB(":memory:", nil)
+		userHandler := NewSyncUserHandler(uid, db, nil)
+		handler := NewCacheHandler(userHandler, DefaultCacheHandlerConfig)
+		collections := []string{
+			"clients", "crypto", "forms", "history", "keys", "meta",
+			"bookmarks", "prefs", "tabs", "passwords", "addons",
+		}
+		for _, cName := range collections {
+			cId, _ := db.GetCollectionId(cName)
+			db.TouchCollection(cId, cId*1000) // turn the cId into milliseconds
+		}
+
+		resp := request("GET", syncurl(uid, "info/collections"), nil, handler)
+		resp2 := request("GET", syncurl(uid, "info/collections"), nil, handler)
+
+		assert.Equal(resp.Body.String(), resp2.Body.String())
+		assert.Equal(resp.Header().Get("X-Last-Modified"), resp2.Header().Get("X-Last-Modified"))
+	}
+}
+
+func TestCacheHandlerInfoConfiguration(t *testing.T) {
+	assert := assert.New(t)
+
+	handler := NewCacheHandler(cacheMockHandler, DefaultCacheHandlerConfig)
+
+	url := syncurl(uniqueUID(), "info/configuration")
+	resp := request("GET", url, nil, handler)
+	assert.Equal(http.StatusOK, resp.Code)
+	assert.True(strings.Contains(resp.Body.String(), `"Type":"info/configuration"`))
+
+	// info/configuration should be global across users (for now)
+	url2 := syncurl(uniqueUID(), "info/configuration")
+	resp2 := request("GET", url2, nil, handler)
+	assert.Equal(http.StatusOK, resp2.Code)
+	assert.Equal(resp.Body.String(), resp2.Body.String(), "Expected same value")
+}
+
+func BenchmarkCacheHandler(b *testing.B) {
+	uid := "123456"
+	db, _ := syncstorage.NewDB(":memory:", nil)
+	userHandler := NewSyncUserHandler(uid, db, nil)
+	handler := NewCacheHandler(userHandler, DefaultCacheHandlerConfig)
+	collections := []string{
+		"clients", "crypto", "forms", "history", "keys", "meta",
+		"bookmarks", "prefs", "tabs", "passwords", "addons",
+	}
+	for _, cName := range collections {
+		cId, _ := db.GetCollectionId(cName)
+		db.TouchCollection(cId, cId*1000) // turn the cId into milliseconds
+	}
+
+	for i := 0; i < b.N; i++ {
+		request("GET", syncurl(uid, "info/collections"), nil, handler)
+	}
+}


### PR DESCRIPTION
CacheHandler will intercept requests for `<uid>/info/collections` and `<uid>/info/configuration` and cache the results. 
This should reduce IO as requests can be
served directly from memory and not go to disk
- Caches <uid>/info/collections
- Caches <uid>/info/configuration
- Configurable cache size (in MB)
