### PR TITLE
Add auto vacuum of databases and reduce blocking of BSO and batch purges

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Things that probably shouldn't be touched:
 |---|---|
 | `POOL_NUM` | Number of DB pools. Defaults to number of CPUs.  |
 | `POOL_SIZE` | Number of open DB files per pool. Defaults to `25`.  |
+| `POOL_VACUUM_KB` | Threshold of free space in kilobytes to trigger a database vacuum. Defaults to `0` (disabled). |
 
 go-syncstorage limits the number of open SQLite database files to keep memory usage constant. This allows a small server to handle thousands of users for a small performance hit.
 
@@ -67,6 +68,8 @@ A low level lock is used in each pool when opening and closing files. Having a l
 When a pool reaches `POOL_SIZE` number of open files it will close the least recently used database. Having a larger `POOL_SIZE` reduces open/close disk IO. It also increases memory usage.
 
 Tweaking these values from default won't provide significant performance gains in production. However, a `POOL_NUM=1` and `POOL_SIZE=1` is useful for testing the overhead of opening and closing databases files.
+
+The `POOL_VACUUM_KB` variable should be enabled with caution. It can cause very high IO if a threshold is too low and users have large databases. This may cause erratic performance. It may be more optimal to schedule a downtime and manually vacuum individual databases to recover space.
 
 ### Sqlite3 Tweaks 
 

--- a/config/config.go
+++ b/config/config.go
@@ -35,8 +35,9 @@ type UserHandlerConfig struct {
 }
 
 type PoolConfig struct {
-	Num     int `envconfig:"default=0"`
-	MaxSize int `envconfig:"default=25"`
+	Num      int `envconfig:"default=0"`
+	MaxSize  int `envconfig:"default=25"`
+	VacuumKB int `envconfig:"default=0"`
 }
 
 type SqliteConfig struct {
@@ -154,6 +155,10 @@ func init() {
 
 	if Config.InfoCacheSize < 0 {
 		log.Fatal("INFO_CACHE_SIZE must be >= 0")
+	}
+
+	if Config.Pool.VacuumKB < 0 {
+		log.Fatal("POOL_VACUUM_KB must be >= 0")
 	}
 
 	Hostname = Config.Hostname

--- a/server.go
+++ b/server.go
@@ -47,6 +47,7 @@ func main() {
 		Basepath:    config.DataDir,
 		NumPools:    config.Pool.Num,
 		MaxPoolSize: config.Pool.MaxSize,
+		VacuumKB:    config.Pool.VacuumKB,
 		DBConfig:    &syncstorage.Config{config.Sqlite.CacheSize},
 	}, syncLimitConfig)
 
@@ -104,6 +105,7 @@ func main() {
 		"PID":                            os.Getpid(),
 		"POOL_NUM":                       config.Pool.Num,
 		"POOL_MAX_SIZE":                  config.Pool.MaxSize,
+		"POOL_VACUUM_KB":                 config.Pool.VacuumKB,
 		"LIMIT_MAX_BSO_GET_LIMIT":        syncLimitConfig.MaxBSOGetLimit,
 		"LIMIT_MAX_POST_RECORDS":         syncLimitConfig.MaxPOSTRecords,
 		"LIMIT_MAX_POST_BYTES":           syncLimitConfig.MaxPOSTBytes,

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -690,14 +690,21 @@ func (d *DB) Optimize(thresholdPercent int) (ItHappened bool, err error) {
 		return
 	}
 
-	d.Lock()
-	defer d.Unlock()
-
 	if stats.FreePercent() >= thresholdPercent {
-		_, err = d.db.Exec("VACUUM")
+		err = d.Vacuum()
 		ItHappened = true
 	}
 
+	return
+}
+
+// Vacuum recovers free disk pages and reduces fragmentation of the
+// data on disk. This could take a long time depending on the size
+// of the database
+func (d *DB) Vacuum() (err error) {
+	d.Lock()
+	defer d.Unlock()
+	_, err = d.db.Exec("VACUUM")
 	return
 }
 

--- a/web/syncPoolHandler_test.go
+++ b/web/syncPoolHandler_test.go
@@ -26,7 +26,7 @@ func TestSyncPoolHandlerStatusConflict(t *testing.T) {
 	uid := uniqueUID()
 	handler := NewSyncPoolHandler(testSyncPoolConfig(), nil)
 
-	el, err := handler.pools[0].getElement(uid)
+	el, _, err := handler.pools[0].getElement(uid)
 	if !assert.NoError(err) {
 		return
 	}


### PR DESCRIPTION
- Refactor purge code out of web/syncPoolHandler's getElement() so
  purging does not block a whole pool until it is finished
- Added configurable threshold for when a user's database is vacuumed.
  This could reduce wasted disk space and keep performance consistent
