### PR TITLE
Send 401 to force clients to reauth when URL/token UID out of sync

### DIFF
--- a/web/hawkHandler.go
+++ b/web/hawkHandler.go
@@ -116,7 +116,11 @@ func (h *HawkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if strings.HasPrefix(r.URL.Path, "/1.5/") {
 		pathUID := extractUID(r.URL.Path)
 		if session.Token.UidString() != pathUID {
-			sendRequestProblem(w, r, http.StatusBadRequest,
+			// Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1304137
+			// a strange series of events can cause clients to use a token that doesn't
+			// match the URL. Sending a 401 should cause clients to abort, fetch a new token
+			// and regenerate the correct URL
+			sendRequestProblem(w, r, http.StatusUnauthorized,
 				errors.Errorf("Hawk: UID in URL (%s) != Token UID (%s)", pathUID, session.Token.UidString()))
 			return
 		}

--- a/web/hawkHandler_test.go
+++ b/web/hawkHandler_test.go
@@ -98,7 +98,7 @@ func TestHawkUidMismatchFails(t *testing.T) {
 	// provide a different UID in the sync url
 	req, _ := hawkrequest("GET", syncurl("67890", "info/collections"), tok)
 	resp := sendrequest(req, hawkH)
-	assert.Equal(t, http.StatusBadRequest, resp.Code)
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
 }
 
 func TestHawkMultiSecrets(t *testing.T) {


### PR DESCRIPTION
On the prototype production server we see users sending tokens with UIDs that do match the one in URL. After some discussion sending a 401 instead of a 400 in this case will cause clients to reauthenticate and regenerate the URL. 
