### PR TITLE
Refactor BSO Purge to be less aggressive

### DIFF
--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -1119,3 +1119,21 @@ func TestDeleteEverything(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(100, cTest)
 }
+
+func TestGetSetKeyValue(t *testing.T) {
+	assert := assert.New(t)
+	db, _ := getTestDB()
+
+	value, err := db.GetKey("testing")
+	if !assert.NoError(err) || !assert.Equal("", value) {
+		return
+	}
+
+	if !assert.NoError(db.SetKey("testing", "12345")) {
+		return
+	}
+
+	if val, err := db.GetKey("testing"); assert.NoError(err) {
+		assert.Equal("12345", val)
+	}
+}

--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -135,7 +135,7 @@ func (s *SyncPoolHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if newElement {
-		element.handler.TidyUp(s.config.VacuumKB)
+		element.handler.TidyUp(12*time.Hour, s.config.VacuumKB)
 	}
 
 	// pass it on


### PR DESCRIPTION
Previously everytime a DB file is opened a purge will be
attempted. Users with a large number of BSOs will incur a full table
scan on BSO.ttl which causes a lot of IO.

The prototype server has shown that out of 66,309 purges only 67 (0.1%)
resulted in any actual deletion of data. This is much too aggressive.

Changes:
- TidyUp will skip purging if not enough time has past since last tidy
- Pool will only cleanup when a db is opened, once every 12 hours
