### PR TITLE
Change Hawk errors to result in HTTP 400 from 401

### DIFF
--- a/web/hawkHandler_test.go
+++ b/web/hawkHandler_test.go
@@ -211,7 +211,7 @@ func TestHawkReplayNonce(t *testing.T) {
 	assert.Equal(http.StatusOK, resp1.Code)
 
 	resp2 := sendrequest(req1, hawkH)
-	assert.Equal(http.StatusUnauthorized, resp2.Code)
+	assert.Equal(http.StatusBadRequest, resp2.Code)
 	assert.Contains(resp2.Body.String(), "Hawk: Replay nonce=")
 
 }

--- a/web/hawkHandler_test.go
+++ b/web/hawkHandler_test.go
@@ -211,7 +211,7 @@ func TestHawkReplayNonce(t *testing.T) {
 	assert.Equal(http.StatusOK, resp1.Code)
 
 	resp2 := sendrequest(req1, hawkH)
-	assert.Equal(http.StatusBadRequest, resp2.Code)
+	assert.Equal(http.StatusForbidden, resp2.Code)
 	assert.Contains(resp2.Body.String(), "Hawk: Replay nonce=")
 
 }


### PR DESCRIPTION
A HTTP 401 reponse triggers clients to fetch new tokens from the tokenserver. 

However, many of the hawk errors seen on the production prototype can not be
fixed with a fresh token. This PR changes these hawk errors from 401 Unauthorized responses to 400 Bad Request. 

The hawk errors that are usually seen are:
- timestamp skew (>60s) so the hawk token is invalid
- nonce replay, this is likely a client issues since it only affects a handful of users
  - possibly an unofficial client that looks like FF
