### PR TITLE
Increase bso/batch purge interval be randomly between one and two weeks

### DIFF
--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -3,6 +3,7 @@ package web
 import (
 	"crypto/sha1"
 	"encoding/binary"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"time"
@@ -135,7 +136,10 @@ func (s *SyncPoolHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if newElement {
-		element.handler.TidyUp(12*time.Hour, s.config.VacuumKB)
+		// between one and two weeks. The random interval spreads
+		// the load from cleanups more evenly around
+		tidyThreshold := time.Duration(128*rand.Intn(168)) * time.Hour
+		element.handler.TidyUp(tidyThreshold, s.config.VacuumKB)
 	}
 
 	// pass it on

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -156,13 +156,6 @@ func (s *SyncUserHandler) TidyUp(purgeFrequency time.Duration, vacuumKB int) (sk
 		return
 	}
 
-	log.WithFields(log.Fields{
-		"uid":            s.uid,
-		"bsos_purged":    numBSOPurged,
-		"batches_purged": numBatchesPurged,
-		"t":              (time.Since(start).Nanoseconds() / 1000 / 1000),
-	}).Info("SyncUserHandler - Purge OK")
-
 	usage, err := s.db.Usage()
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -172,7 +165,16 @@ func (s *SyncUserHandler) TidyUp(purgeFrequency time.Duration, vacuumKB int) (sk
 		return
 	}
 
-	if vacuumKB > 0 && (usage.Free*usage.Size/1024) >= vacuumKB {
+	freeKB := (usage.Free * usage.Size / 1024)
+	log.WithFields(log.Fields{
+		"uid":            s.uid,
+		"bsos_purged":    numBSOPurged,
+		"batches_purged": numBatchesPurged,
+		"t":              (time.Since(start).Nanoseconds() / 1000 / 1000),
+		"free_kb":        freeKB,
+	}).Info("SyncUserHandler - Purge OK")
+
+	if vacuumKB > 0 && freeKB >= vacuumKB {
 		if err = s.db.Vacuum(); err != nil {
 			log.WithFields(log.Fields{
 				"uid": s.uid,


### PR DESCRIPTION
- purge happens between 168 and 336 hours. This should even out purge
  read IO load spikes during busy times
- add logging of free (wasted) space in kb for a user to help with
  determining the vacuum threshold
