### PR TITLE
Bugfix: Fix bug in TidyUp scheduling

### DIFF
--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -138,7 +138,7 @@ func (s *SyncPoolHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if newElement {
 		// between one and two weeks. The random interval spreads
 		// the load from cleanups more evenly around
-		tidyThreshold := time.Duration(168*rand.Intn(168)) * time.Hour
+		tidyThreshold := time.Duration(168+rand.Intn(168)) * time.Hour
 		element.handler.TidyUp(tidyThreshold, s.config.VacuumKB)
 	}
 


### PR DESCRIPTION
- fixed TidyUp threshold math. Used a \* instead of a +
  - this worked on the prod by accident as soemtimes rand.Intn would be
    zero
- made syncUserHandler.TidyUp a bit more robust for dealing with errors
