### PR TITLE
Fix broken logging of token payload in PR #137

### DIFF
--- a/web/hawkHandler_test.go
+++ b/web/hawkHandler_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -75,10 +76,12 @@ func hawkrequestbody(
 func testtoken(secret string, uid uint64) token.Token {
 	node := "https://syncnode-12345.services.mozilla.com"
 	payload := token.TokenPayload{
-		Uid:     uid,
-		Node:    node,
-		Expires: float64(syncstorage.Now()+60) / 1000,
-		Salt:    "pacific",
+		Uid:      uid,
+		Node:     node,
+		Expires:  float64(syncstorage.Now()+60) / 1000,
+		Salt:     "pacific",
+		FxaUID:   "fxa_" + strconv.FormatUint(uid, 10),
+		DeviceId: "device_" + strconv.FormatUint(uid, 10),
 	}
 
 	tok, err := token.NewToken([]byte(secret), payload)


### PR DESCRIPTION
In PR #137 the hawkHandler creates a _new_ request with the token data
in the session context. Since the logHandler wraps all other handlers
this means the logHandler's request object's context is not the same as
the one passed down through the HawkHandler.

The solution is to be smarter with how the session is handled. The
logHandler will reuse or create a session before passing the request
along. The HawkHandler will also do this so it does not rely on any
upstream handler's to reduce coupling between handlers.

A new test was added to make sure a session is correctly reused so the
fxa_uid and device_id can be logged.
