### PR TITLE
Add min/max bso purge time to pool configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,9 +35,11 @@ type UserHandlerConfig struct {
 }
 
 type PoolConfig struct {
-	Num      int `envconfig:"default=0"`
-	MaxSize  int `envconfig:"default=25"`
-	VacuumKB int `envconfig:"default=0"`
+	Num           int `envconfig:"default=0"`
+	MaxSize       int `envconfig:"default=25"`
+	PurgeMinHours int `envconfig:"default=168"`
+	PurgeMaxHours int `envconfig:"default=336"`
+	VacuumKB      int `envconfig:"default=0"`
 }
 
 type SqliteConfig struct {
@@ -159,6 +161,15 @@ func init() {
 
 	if Config.Pool.VacuumKB < 0 {
 		log.Fatal("POOL_VACUUM_KB must be >= 0")
+	}
+	if Config.Pool.PurgeMinHours <= 0 {
+		log.Fatal("POOL_MIN_HOURS must be > 0")
+	}
+	if Config.Pool.PurgeMaxHours <= 0 {
+		log.Fatal("POOL_MAX_HOURS must be > 0")
+	}
+	if Config.Pool.PurgeMaxHours < Config.Pool.PurgeMinHours {
+		log.Fatal("POOL_MAX_HOURS must be > POOL_MIN_HOURS")
 	}
 
 	Hostname = Config.Hostname

--- a/server.go
+++ b/server.go
@@ -44,11 +44,13 @@ func main() {
 
 	// The base functionality is the sync 1.5 api
 	poolHandler := web.NewSyncPoolHandler(&web.SyncPoolConfig{
-		Basepath:    config.DataDir,
-		NumPools:    config.Pool.Num,
-		MaxPoolSize: config.Pool.MaxSize,
-		VacuumKB:    config.Pool.VacuumKB,
-		DBConfig:    &syncstorage.Config{config.Sqlite.CacheSize},
+		Basepath:      config.DataDir,
+		NumPools:      config.Pool.Num,
+		MaxPoolSize:   config.Pool.MaxSize,
+		VacuumKB:      config.Pool.VacuumKB,
+		DBConfig:      &syncstorage.Config{config.Sqlite.CacheSize},
+		PurgeMinHours: config.Pool.PurgeMinHours,
+		PurgeMaxHours: config.Pool.PurgeMaxHours,
 	}, syncLimitConfig)
 
 	var router http.Handler
@@ -106,6 +108,8 @@ func main() {
 		"POOL_NUM":                       config.Pool.Num,
 		"POOL_MAX_SIZE":                  config.Pool.MaxSize,
 		"POOL_VACUUM_KB":                 config.Pool.VacuumKB,
+		"POOL_PURGE_MIN_HOURS":           config.Pool.PurgeMinHours,
+		"POOL_PURGE_MAX_HOURS":           config.Pool.PurgeMaxHours,
 		"LIMIT_MAX_BSO_GET_LIMIT":        syncLimitConfig.MaxBSOGetLimit,
 		"LIMIT_MAX_POST_RECORDS":         syncLimitConfig.MaxPOSTRecords,
 		"LIMIT_MAX_POST_BYTES":           syncLimitConfig.MaxPOSTBytes,

--- a/web/syncPoolHandler_test.go
+++ b/web/syncPoolHandler_test.go
@@ -8,11 +8,10 @@ import (
 )
 
 func testSyncPoolConfig() *SyncPoolConfig {
-	return &SyncPoolConfig{
-		Basepath:    ":memory:",
-		NumPools:    1,
-		MaxPoolSize: 10,
-	}
+	config := NewDefaultSyncPoolConfig(":memory:")
+	config.NumPools = 1
+	config.MaxPoolSize = 10
+	return config
 }
 
 func TestSyncPoolHandlerStatusConflict(t *testing.T) {


### PR DESCRIPTION
- refactored TidyUp logic to set a NEXT_PURGE time instead of
  relying on a random time span
- made the purge range configurable
- update documentation for new configuration values
