### PR TITLE
Skip TidyUp on no NEXT_PURGE value

### DIFF
--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -150,6 +150,11 @@ func (s *SyncUserHandler) TidyUp(minPurge, maxPurge time.Duration, vacuumKB int)
 			}
 			return true, took, nil
 		}
+	} else {
+		// never been purged, skip it and set it to the maxpurge time in the future
+		nextPurge := time.Now().Add(maxPurge)
+		err = s.db.SetKey("NEXT_PURGE", nextPurge.Format(time.RFC3339Nano))
+		return true, time.Since(start), err
 	}
 
 	numBSOPurged, err := s.db.PurgeExpired()

--- a/web/syncUserHandler_test.go
+++ b/web/syncUserHandler_test.go
@@ -409,11 +409,10 @@ func TestSyncUserHandlerTidyUp(t *testing.T) {
 		config.MaxBatchTTL = 1
 		handler := NewSyncUserHandler(uniqueUID(), db, config)
 
-		// no purge value in db will always cleanup
-		// this should set a new purge value
+		// no purge value in db will always skip, pointless doing a purge
 		minPurge := 10 * time.Millisecond
 		skipped, _, err := handler.TidyUp(minPurge, minPurge, 1)
-		if !assert.NoError(err) || !assert.False(skipped, "Expected a purge to happen") {
+		if !assert.NoError(err) || !assert.True(skipped, "Expected to skip") {
 			return
 		}
 
@@ -442,6 +441,9 @@ func TestSyncUserHandlerTidyUp(t *testing.T) {
 
 		payload := "hi"
 		ttl := 1
+
+		// write the NEXT_PURGE value
+		handler.TidyUp(time.Nanosecond, time.Nanosecond, 1)
 
 		// remember the size a new db
 		usageOrig, _ := db.Usage()


### PR DESCRIPTION
Fix an edge case where logic was changed and deployed and a huge load
spike resulted since a missing NEXT_PURGE value triggers a purge. This
change sets the key and skips the purge instead.
