### PR TITLE
Support for `older` parameter for fetching BSOs

### DIFF
--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -556,7 +556,9 @@ func (d *DB) GetBSO(cId int, bId string) (b *BSO, err error) {
 func (d *DB) GetBSOs(
 	cId int,
 	ids []string,
+	older int,
 	newer int,
+
 	sort SortType,
 	limit int,
 	offset int) (r *GetResults, err error) {
@@ -564,7 +566,7 @@ func (d *DB) GetBSOs(
 	d.Lock()
 	defer d.Unlock()
 
-	r, err = d.getBSOs(d.db, cId, ids, newer, sort, limit, offset)
+	r, err = d.getBSOs(d.db, cId, ids, older, newer, sort, limit, offset)
 
 	return
 }
@@ -831,6 +833,7 @@ func (d *DB) getBSOs(
 	tx dbTx,
 	cId int,
 	ids []string,
+	older int,
 	newer int,
 	sort SortType,
 	limit int,
@@ -850,8 +853,8 @@ func (d *DB) getBSOs(
 
 	cutOffTTL := Now()
 	query := "SELECT Id, SortIndex, Payload, Modified, TTL FROM BSO "
-	where := "WHERE CollectionId=? AND Modified > ? AND TTL > ?"
-	values := []interface{}{cId, newer, cutOffTTL}
+	where := "WHERE CollectionId=? AND Modified < ? AND Modified > ? AND TTL > ?"
+	values := []interface{}{cId, older, newer, cutOffTTL}
 
 	if len(ids) > 0 {
 		// spec says only 100 ids at a time

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -329,12 +329,12 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 	offset := 0
 
 	// make sure invalid values don't work for limit and offset
-	_, err := db.getBSOs(tx, cId, nil, newer, SORT_INDEX, -1, offset)
+	_, err := db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, -1, offset)
 	assert.Equal(ErrInvalidLimit, err)
-	_, err = db.getBSOs(tx, cId, nil, newer, SORT_INDEX, limit, -1)
+	_, err = db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, limit, -1)
 	assert.Equal(ErrInvalidOffset, err)
 
-	results, err := db.getBSOs(tx, cId, nil, newer, SORT_NEWEST, limit, offset)
+	results, err := db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_NEWEST, limit, offset)
 	assert.NoError(err)
 
 	if assert.NotNil(results) {
@@ -348,7 +348,7 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 		assert.Equal("7", results.BSOs[4].Id, "Expected BSO w/ Id = 7")
 	}
 
-	results2, err := db.getBSOs(tx, cId, nil, newer, SORT_INDEX, limit, results.Offset)
+	results2, err := db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, limit, results.Offset)
 	assert.NoError(err)
 	if assert.NotNil(results2) {
 		assert.Equal(5, len(results2.BSOs), "Expected 5 results")
@@ -361,7 +361,7 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 		assert.Equal("2", results2.BSOs[4].Id, "Expected BSO w/ Id = 9")
 	}
 
-	results3, err := db.getBSOs(tx, cId, nil, newer, SORT_INDEX, limit, results2.Offset)
+	results3, err := db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, limit, results2.Offset)
 	assert.NoError(err)
 	if assert.NotNil(results3) {
 		assert.Equal(2, len(results3.BSOs), "Expected 2 results")
@@ -390,14 +390,14 @@ func TestPrivateGetBSOsNewer(t *testing.T) {
 
 	modified := Now()
 
-	_, err := db.getBSOs(tx, cId, nil, -1, SORT_NONE, 10, 0)
+	_, err := db.getBSOs(tx, cId, nil, MaxTimestamp, -1, SORT_NONE, 10, 0)
 	assert.Equal(ErrInvalidNewer, err)
 
 	assert.Nil(db.insertBSO(tx, cId, "b2", modified-2, "a", 1, DEFAULT_BSO_TTL))
 	assert.Nil(db.insertBSO(tx, cId, "b1", modified-1, "a", 1, DEFAULT_BSO_TTL))
 	assert.Nil(db.insertBSO(tx, cId, "b0", modified, "a", 1, DEFAULT_BSO_TTL))
 
-	results, err := db.getBSOs(tx, cId, nil, modified-3, SORT_NEWEST, 10, 0)
+	results, err := db.getBSOs(tx, cId, nil, MaxTimestamp, modified-3, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(3, results.Total)
@@ -407,7 +407,7 @@ func TestPrivateGetBSOsNewer(t *testing.T) {
 		assert.Equal("b2", results.BSOs[2].Id)
 	}
 
-	results, err = db.getBSOs(tx, cId, nil, modified-2, SORT_NEWEST, 10, 0)
+	results, err = db.getBSOs(tx, cId, nil, MaxTimestamp, modified-2, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(2, results.Total)
@@ -415,14 +415,14 @@ func TestPrivateGetBSOsNewer(t *testing.T) {
 		assert.Equal("b1", results.BSOs[1].Id)
 	}
 
-	results, err = db.getBSOs(tx, cId, nil, modified-1, SORT_NEWEST, 10, 0)
+	results, err = db.getBSOs(tx, cId, nil, MaxTimestamp, modified-1, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(1, results.Total)
 		assert.Equal("b0", results.BSOs[0].Id)
 	}
 
-	results, err = db.getBSOs(tx, cId, nil, modified, SORT_NEWEST, 10, 0)
+	results, err = db.getBSOs(tx, cId, nil, MaxTimestamp, modified, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(0, results.Total)
@@ -445,14 +445,14 @@ func TestPrivateGetBSOsSort(t *testing.T) {
 
 	modified := Now()
 
-	_, err := db.getBSOs(tx, cId, nil, -1, SORT_NONE, 10, 0)
+	_, err := db.getBSOs(tx, cId, nil, MaxTimestamp, -1, SORT_NONE, 10, 0)
 	assert.Equal(ErrInvalidNewer, err)
 
 	assert.Nil(db.insertBSO(tx, cId, "b2", modified-2, "a", 2, DEFAULT_BSO_TTL))
 	assert.Nil(db.insertBSO(tx, cId, "b1", modified-1, "a", 0, DEFAULT_BSO_TTL))
 	assert.Nil(db.insertBSO(tx, cId, "b0", modified, "a", 1, DEFAULT_BSO_TTL))
 
-	results, err := db.getBSOs(tx, cId, nil, 0, SORT_NEWEST, 10, 0)
+	results, err := db.getBSOs(tx, cId, nil, MaxTimestamp, 0, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(3, len(results.BSOs))
@@ -461,7 +461,7 @@ func TestPrivateGetBSOsSort(t *testing.T) {
 		assert.Equal("b2", results.BSOs[2].Id)
 	}
 
-	results, err = db.getBSOs(tx, cId, nil, 0, SORT_OLDEST, 10, 0)
+	results, err = db.getBSOs(tx, cId, nil, MaxTimestamp, 0, SORT_OLDEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(3, len(results.BSOs))
@@ -470,7 +470,7 @@ func TestPrivateGetBSOsSort(t *testing.T) {
 		assert.Equal("b0", results.BSOs[2].Id)
 	}
 
-	results, err = db.getBSOs(tx, cId, nil, 0, SORT_INDEX, 10, 0)
+	results, err = db.getBSOs(tx, cId, nil, MaxTimestamp, 0, SORT_INDEX, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(3, len(results.BSOs))
@@ -897,7 +897,7 @@ func TestGetBSOs(t *testing.T) {
 	}
 
 	// get these 3 and sort them in order of newest
-	results, err := db.GetBSOs(cId, []string{"b0", "b2", "b4"}, 0, SORT_NEWEST, 10, 0)
+	results, err := db.GetBSOs(cId, []string{"b0", "b2", "b4"}, MaxTimestamp, 0, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(3, results.Total)
@@ -906,7 +906,7 @@ func TestGetBSOs(t *testing.T) {
 		assert.Equal("b4", results.BSOs[2].Id) // created first
 	}
 
-	results, err = db.GetBSOs(cId, nil, 0, SORT_INDEX, 2, 0)
+	results, err = db.GetBSOs(cId, nil, MaxTimestamp, 0, SORT_INDEX, 2, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
 		assert.Equal(5, results.Total)

--- a/syncstorage/utils.go
+++ b/syncstorage/utils.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// 2099 ... somebody else's problem by then (I hope)
+const MaxTimestamp = 4070822400000
+
 var (
 	bsoIdCheck *regexp.Regexp
 	cNameCheck *regexp.Regexp


### PR DESCRIPTION
This was requested in bug 1314171 [1] and implemented in PR #53 [2] on the
mozilla/server-syncstorage project.


This shall not be merged until [PR53](https://github.com/mozilla-services/server-syncstorage/pull/53) is merged in mozilla/server-syncstorage

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1314171
[2] https://github.com/mozilla-services/server-syncstorage/pull/53
