### PR TITLE
Fix bugs using sync.Pool for bytes.Buffer

### DIFF
--- a/syncstorage/BSO.go
+++ b/syncstorage/BSO.go
@@ -30,12 +30,13 @@ type BSO struct {
 func (b BSO) MarshalJSON() ([]byte, error) {
 
 	buf := bsoBufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bsoBufferPool.Put(buf)
+
 	buf.WriteString(`{"id":`)
 	if encoded, err := json.Marshal(b.Id); err == nil {
 		buf.Write(encoded)
 	} else {
-		buf.Reset()
-		bsoBufferPool.Put(buf)
 		return nil, err
 	}
 
@@ -46,8 +47,6 @@ func (b BSO) MarshalJSON() ([]byte, error) {
 	if encoded, err := json.Marshal(b.Payload); err == nil {
 		buf.Write(encoded)
 	} else {
-		buf.Reset()
-		bsoBufferPool.Put(buf)
 		return nil, err
 	}
 
@@ -57,8 +56,7 @@ func (b BSO) MarshalJSON() ([]byte, error) {
 	}
 
 	buf.WriteString("}")
-	data := buf.Bytes()
-	buf.Reset()
-	bsoBufferPool.Put(buf)
-	return data, nil
+	c := make([]byte, buf.Len())
+	copy(c, buf.Bytes())
+	return c, nil
 }

--- a/web/logHandler.go
+++ b/web/logHandler.go
@@ -156,10 +156,8 @@ func (f *MozlogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	}
 
 	b := encoderPool.Get().(*bytes.Buffer)
-	defer func() {
-		b.Reset()
-		encoderPool.Put(b)
-	}()
+	b.Reset()
+	defer encoderPool.Put(b)
 
 	// encode the fields in there
 	enc := json.NewEncoder(b)
@@ -167,7 +165,9 @@ func (f *MozlogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 		return nil, err
 	}
 
-	return b.Bytes(), nil
+	c := make([]byte, b.Len())
+	copy(c, b.Bytes())
+	return c, nil
 }
 
 /*


### PR DESCRIPTION
Previous code just returned the slice from Buffer.Bytes(). However,
when the sync.Pool reused the buffer the underlying byte array changed.
So the returned sliced pointed at mutated data. To fix this the bytes
are copied to a new slice before being returned.