### PR TITLE
Fix #147 Remove double logging of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ The server has a few knobs that can be tweaked.
 | `DATA_DIR` | Where to save DB files. Use an absolute path. `:memory:` is also valid and saves sqlite databases in RAM only. Recommended only during testing and development. |
 | `SECRETS` | Comma separated list of shared secrets. Secrets are tried in order and allows for secret rotation without downtime. |
 | `LOG_LEVEL`| Log verbosity, allowed: `fatal`,`error`,`warn`,`debug`,`info`|
-| `LOG_MOZLOG` | Can be `true` or `false`. Outputs logs in [mozlog](https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md) format. |
-| `LOG_DISABLE_HTTP` | Can be `true` or `false`. Disables logging of HTTP requests. |
+| `LOG_MOZLOG` | Can be `true` or `false`. Outputs logs in [mozlog](https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md) format. Default `false`.|
+| `LOG_DISABLE_HTTP` | Can be `true` or `false`. Disables logging of HTTP requests. Default `false`. |
+| `LOG_ONLY_HTTP_ERRORS` | Can be `true` or `false`. Logs only when `errno != 0` to reduce noise. Default `false`. |
 | `HOSTNAME` | Set a hostname value for mozlog output |
 | `LIMIT_MAX_REQUESTS_BYTES` | The maximum size in bytes of the overall HTTP request body that will be accepted by the server. |
 | `LIMIT_MAX_BSO_GET_LIMIT` |  Max BSOs that can be returned per GET request. Default: 2500. |

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,9 @@ type LogConfig struct {
 
 	// Disable HTTP Logging
 	DisableHTTP bool `envconfig:"default=false"`
+
+	// Filter out all messages where errno=0
+	OnlyHTTPErrors bool `envconfig:"default=false"`
 }
 
 // configures limits for web/SyncUserHandler
@@ -80,8 +83,6 @@ var (
 	EnablePprof bool
 
 	Limit *UserHandlerConfig
-
-	DisableHTTPLogs bool
 
 	InfoCacheSize int
 )

--- a/server.go
+++ b/server.go
@@ -71,7 +71,14 @@ func main() {
 
 	// Log all the things
 	if config.Log.DisableHTTP != true {
-		router = web.NewLogHandler(log.StandardLogger(), router)
+		logHandler := web.NewLogHandler(log.StandardLogger(), router)
+
+		if config.Log.OnlyHTTPErrors {
+			h := logHandler.(*web.LoggingHandler)
+			h.OnlyHTTPErrors = true
+		}
+
+		router = logHandler
 	}
 
 	if config.EnablePprof {

--- a/web/misc.go
+++ b/web/misc.go
@@ -371,26 +371,11 @@ func sendRequestProblem(w http.ResponseWriter, req *http.Request, responseCode i
 		req.Body.Close()
 	}
 
-	logRequestProblem(req, responseCode, reason)
-	JSONError(w, reason.Error(), responseCode)
-}
-
-func logRequestProblem(req *http.Request, responseCode int, reason error) {
-	var causeMessage string
-	if cause := errors.Cause(reason); cause != nil && cause != reason {
-		causeMessage = fmt.Sprintf("%v", cause)
-	} else {
-		causeMessage = "n/a"
+	if session, ok := SessionFromContext(req.Context()); ok {
+		session.ErrorResult = reason
 	}
 
-	log.WithFields(log.Fields{
-		"method":    req.Method,
-		"path":      req.URL.Path,
-		"ua":        req.UserAgent(),
-		"http_code": responseCode,
-		"error":     reason.Error(),
-		"cause":     causeMessage,
-	}).Warning("HTTP Request Problem")
+	JSONError(w, reason.Error(), responseCode)
 }
 
 // getMediaType extracts the mediatype portion from the http request header Content-Type

--- a/web/session.go
+++ b/web/session.go
@@ -11,7 +11,8 @@ type sessionKey int
 var sKey sessionKey = 0
 
 type Session struct {
-	Token token.TokenPayload
+	Token       token.TokenPayload
+	ErrorResult error
 }
 
 func NewSessionContext(ctx context.Context, ses *Session) context.Context {

--- a/web/weaveHandler.go
+++ b/web/weaveHandler.go
@@ -24,14 +24,18 @@ const (
 )
 
 func WeaveInvalidWBOError(w http.ResponseWriter, r *http.Request, reason error) {
-	logRequestProblem(r, http.StatusBadRequest, reason)
+	if session, ok := SessionFromContext(r.Context()); ok {
+		session.ErrorResult = reason
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	w.Write([]byte(WEAVE_INVALID_WBO))
 }
 
 func WeaveSizeLimitExceeded(w http.ResponseWriter, r *http.Request, reason error) {
-	logRequestProblem(r, http.StatusBadRequest, reason)
+	if session, ok := SessionFromContext(r.Context()); ok {
+		session.ErrorResult = reason
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
 	w.Write([]byte(WEAVE_SIZE_LIMIT_EXCEEDED))


### PR DESCRIPTION
- remove the extra logging in web.sendRequestProblem
- put the error in req.Context which is read by web.LoggingHandler
- add log config OnlyHTTPErrors to disable logging of noisy success
  lines
- add config LOG_ONLY_HTTP_ERRORS to reduce logging noise when debugging