### PR TITLE
Add HAWK_TIMESTAMP_MAX_SKEW configuration knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ The server has a few knobs that can be tweaked.
 |---|---|
 | `HOST` | Address to listen on. Defaults to `0.0.0.0`. |
 | `PORT` | Port to listen on |
-| `DATA_DIR` | Where to save DB files. Use an absolute path. `:memory:` is also valid and saves sqlite databases in RAM only. Recommended only during testing and development. |
+| `DATA_DIR` | Where to save DB files. Use an absolute path. `:memory:` is valid and saves databases in RAM but recommended only for testing. |
 | `SECRETS` | Comma separated list of shared secrets. Secrets are tried in order and allows for secret rotation without downtime. |
-| `LOG_LEVEL`| Log verbosity, allowed: `fatal`,`error`,`warn`,`debug`,`info`|
+| `LOG_LEVEL`| Log verbosity, allowed: `fatal`,`error`,`warn`,`debug`,`info`. Default `info`. |
 | `LOG_MOZLOG` | Can be `true` or `false`. Outputs logs in [mozlog](https://github.com/mozilla-services/Dockerflow/blob/master/docs/mozlog.md) format. Default `false`.|
 | `LOG_DISABLE_HTTP` | Can be `true` or `false`. Disables logging of HTTP requests. Default `false`. |
 | `LOG_ONLY_HTTP_ERRORS` | Can be `true` or `false`. Logs only when `errno != 0` to reduce noise. Default `false`. |
@@ -50,6 +50,7 @@ The server has a few knobs that can be tweaked.
 | `LIMIT_MAX_TOTAL_RECORDS` | Maximum total BSOs in a POST batch job. Default 1000. |
 | `LIMIT_MAX_BATCH_TTL` | Maximum TTL for a batch to remain uncommitted in seconds. Default 7200 (2 hours). |
 | `INFO_CACHE_SIZE` | Cache size in MB for `<uid>/info/collections` and `<uid>/info/configuration`. Default 0 (disabled) | 
+| `HAWK_TIMESTAMP_MAX_SKEW` | Sets number of seconds hawk timestamps can differ from the server. Default 60. |
 
 ## Advanced Configuration
 

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,9 @@ var Config struct {
 
 	// cache size in MB for /info/collections cache
 	InfoCacheSize int `envconfig:"default=0"`
+
+	// max skew for hawk timestamps in seconds
+	HawkTimestampMaxSkew int `envconfig:"default=60"`
 }
 
 // so we can use config.Port and not config.Config.Port
@@ -84,7 +87,8 @@ var (
 
 	Limit *UserHandlerConfig
 
-	InfoCacheSize int
+	InfoCacheSize        int
+	HawkTimestampMaxSkew int
 )
 
 func init() {
@@ -173,6 +177,10 @@ func init() {
 		log.Fatal("POOL_MAX_HOURS must be > POOL_MIN_HOURS")
 	}
 
+	if Config.HawkTimestampMaxSkew < 60 {
+		log.Fatal("HAWK_TIMESTAMP_MAX_SKEW must be >= 60")
+	}
+
 	Hostname = Config.Hostname
 	Log = Config.Log
 	Host = Config.Host
@@ -184,4 +192,5 @@ func init() {
 	Limit = Config.Limit
 	Sqlite = Config.Sqlite
 	InfoCacheSize = Config.InfoCacheSize
+	HawkTimestampMaxSkew = Config.HawkTimestampMaxSkew
 }

--- a/server.go
+++ b/server.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"go.mozilla.org/hawk"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/facebookgo/httpdown"
 
@@ -31,6 +33,8 @@ func init() {
 }
 
 func main() {
+
+	hawk.MaxTimestampSkew = time.Second * time.Duration(config.HawkTimestampMaxSkew)
 
 	syncLimitConfig := web.NewDefaultSyncUserHandlerConfig()
 	syncLimitConfig.MaxRequestBytes = config.Limit.MaxRequestBytes
@@ -127,6 +131,7 @@ func main() {
 		"LIMIT_MAX_RECORD_PAYLOAD_BYTES": syncLimitConfig.MaxRecordPayloadBytes,
 		"SQLITE3_CACHE_SIZE":             config.Sqlite.CacheSize,
 		"INFO_CACHE_SIZE":                config.InfoCacheSize,
+		"HAWK_TIMESTAMP_MAX_SKEW":        hawk.MaxTimestampSkew.Seconds(),
 	}).Info("HTTP Listening at " + listenOn)
 
 	err := httpdown.ListenAndServe(server, hd)

--- a/web/hawkHandler.go
+++ b/web/hawkHandler.go
@@ -126,7 +126,7 @@ func (h *HawkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// special case, want to see how far client clocks are off
 		if err == hawk.ErrTimestampSkew {
 			skew := auth.ActualTimestamp.Sub(auth.Timestamp)
-			sendRequestProblem(w, r, http.StatusForbidden, errors.Errorf("Hawk: tiemstamp skew too large %0.3f", skew.Seconds()))
+			sendRequestProblem(w, r, http.StatusForbidden, errors.Errorf("Hawk: timestamp skew too large %0.3f", skew.Seconds()))
 		} else {
 			sendRequestProblem(w, r, http.StatusForbidden, errors.Wrap(err, "Hawk: auth invalid"))
 		}


### PR DESCRIPTION
Client clocks in the wild can be greatly inaccurate, sometimes off by
months. The HAWK_TIMESTAMP_MAX_SKEW changes the threshold to account for
these bad clocks and reduce 403 responses