### PR TITLE
[Bug 1318799] Send 401 on missing Authorization header

### DIFF
--- a/web/hawkHandler.go
+++ b/web/hawkHandler.go
@@ -87,6 +87,11 @@ func (h *HawkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				authInfo, _ := hawk.ParseRequestHeader(r.Header.Get("Authorization"))
 				sendRequestProblem(w, r, http.StatusForbidden,
 					errors.Errorf("Hawk: Replay nonce=%s", authInfo.Nonce))
+			case hawk.ErrNoAuth:
+				// send a 401 for no Authorization header issues to force clients to
+				// fetch a new token. See https://bugzilla.mozilla.org/show_bug.cgi?id=1318799
+				// reasons.
+				sendRequestProblem(w, r, http.StatusUnauthorized, errors.Wrap(err, "Hawk: AuthError"))
 			default:
 				sendRequestProblem(w, r, http.StatusForbidden, errors.Wrap(err, "Hawk: AuthError"))
 			}

--- a/web/hawkHandler_test.go
+++ b/web/hawkHandler_test.go
@@ -104,6 +104,19 @@ func TestHawkUidMismatchFails(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.Code)
 }
 
+// TestHawkNoAuthorizationError401 tests that the server sends a 401 status when
+// there is no Authorization header. This is legacy behaviour see bug
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1318799
+func TestHawkNoAuthorizationError401(t *testing.T) {
+	var uid uint64 = 12345
+
+	hawkH := NewHawkHandler(EchoHandler, []string{"sekret"})
+
+	// send an authenticated request
+	resp := request("GET", syncurl(uid, "info/collections"), nil, hawkH)
+	assert.Equal(t, http.StatusUnauthorized, resp.Code)
+}
+
 func TestHawkMultiSecrets(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The client actually sends a request with no Authorization header, expecting a 401 to trigger presumably some side effect to fetch a new token from Tokenserver. Let's just stick with the _correct_ legacy behaviour. 