### PR TITLE
Refactor to use go 1.8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,8 @@ machine:
     B: "$A/$CIRCLE_PROJECT_REPONAME"
 
     # Use to install Custom golang
-    GODIST: "go1.7.linux-amd64.tar.gz"
-    GODIST_HASH: "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95"
+    GODIST: "go1.8beta1.linux-amd64.tar.gz"
+    GODIST_HASH: "768d8d73ccea69c9a0941f9ef2333b1ff8c82120abfcdedd4e91af039c674a8d"
 
   services:
     - docker


### PR DESCRIPTION
Tracking issue for moving to go1.8

* New go garbage collector, which reduces pause times to <100 micro seconds 
* Overhead calling C [reduced by half](https://github.com/golang/go/issues/9704). Will be interesting the effect on calling sqlite3
* [Graceful shutdowns of http.Server](https://beta.golang.org/doc/go1.8#http_shutdown)
  * can replace dependency on github.com/facebookgo/httpdown