### PR TITLE
Fix bug 1332552. Treat bsos with ttl:null as never expiring.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -73,11 +73,8 @@ test:
         app:build
     - sleep 3
     - >
-        echo "${PYTHON_TEST_CONTAINER:-mozilla/server-syncstorage:1.6.2}"
-    - >
         docker run
-        --net=host
-        "${PYTHON_TEST_CONTAINER:-mozilla/server-syncstorage:1.6.2}"
+        --net=host mozilla/server-syncstorage:1.6.2
         test_endpoint "http://127.0.0.1:8888#secret"
 
 deployment:

--- a/circle.yml
+++ b/circle.yml
@@ -73,11 +73,11 @@ test:
         app:build
     - sleep 3
     - >
-        echo "${PYTHON_TEST_CONTAINER:-mozilla/server-syncstorage:1.6.1}"
+        echo "${PYTHON_TEST_CONTAINER:-mozilla/server-syncstorage:1.6.2}"
     - >
         docker run
         --net=host
-        "${PYTHON_TEST_CONTAINER:-mozilla/server-syncstorage:1.6.1}"
+        "${PYTHON_TEST_CONTAINER:-mozilla/server-syncstorage:1.6.2}"
         test_endpoint "http://127.0.0.1:8888#secret"
 
 deployment:

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -49,8 +49,9 @@ const (
 	SORT_OLDEST
 	SORT_INDEX
 
-	// Keep BSO for 1 year
-	DEFAULT_BSO_TTL = 365 * 24 * 60 * 60 * 1000
+	// The default TTL is to never expire. Use 100 years
+	// which should be enough (in milliseconds)
+	DEFAULT_BSO_TTL = 100 * 365 * 24 * 60 * 60 * 1000
 )
 
 type CollectionInfo struct {

--- a/web/misc.go
+++ b/web/misc.go
@@ -168,12 +168,19 @@ func parseIntoBSO(jsonData json.RawMessage, bso *syncstorage.PutBSOInput) *parse
 
 	if r, ok := bkeys["ttl"]; ok {
 		var ttl int
-		err := json.Unmarshal(r, &ttl)
-		if err != nil {
-			return &parseError{bId: bId, field: "ttl", msg: "Invalid format"}
+
+		// bug 1332552, treat `ttl:null` as never expiring
+		// by using 100 years for it (in seconds)
+		if len(r) == 4 && string(r[:]) == "null" {
+			ttl = 100 * 365 * 24 * 60 * 60
 		} else {
-			bso.TTL = &ttl
+			err := json.Unmarshal(r, &ttl)
+			if err != nil {
+				return &parseError{bId: bId, field: "ttl", msg: "Invalid format"}
+			}
 		}
+
+		bso.TTL = &ttl
 	}
 
 	if r, ok := bkeys["sortindex"]; ok {

--- a/web/misc.go
+++ b/web/misc.go
@@ -149,7 +149,7 @@ func parseIntoBSO(jsonData json.RawMessage, bso *syncstorage.PutBSOInput) *parse
 	// check to make sure values are appropriate
 	if r, ok := bkeys["id"]; ok {
 		err := json.Unmarshal(r, &bId)
-		if err != nil {
+		if err != nil || (len(r) == 4 && string(r[:]) == "null") {
 			return &parseError{field: "id", msg: "Invalid format"}
 		} else {
 			bso.Id = bId

--- a/web/misc_test.go
+++ b/web/misc_test.go
@@ -187,4 +187,36 @@ func TestParseIntoBSO(t *testing.T) {
 			assert.Equal(100*365*24*60*60, *bso.TTL)
 		}
 	}
+
+	{ // test malformed json explodes
+		tests := []string{
+			`{"id":[]}`,
+			`{"id":123}`,
+			`{"id":{"x":"boom"}}`,
+			`{"id":null}`,
+
+			`{"id":"x", "payload":[]}`,
+			`{"id":"x", "payload":123}`,
+			`{"id":"x", "payload":{"x":"boom"}}`,
+
+			`{"id":"x", "ttl":[]}`,
+			`{"id":"x", "ttl":nu}`,
+			`{"id":"x", "ttl":"null"}`,
+			`{"id":"x", "ttl":{"x":1}}`,
+
+			`{"id":"x", "sortindex":[]}`,
+			`{"id":"x", "sortindex":nu}`,
+			`{"id":"x", "sortindex":"null"}`,
+			`{"id":"x", "sortindex":{"x":1}}`,
+		}
+
+		for _, test := range tests {
+			var bso syncstorage.PutBSOInput
+			err := parseIntoBSO(json.RawMessage(test), &bso)
+			if !assert.NotNil(err, test) {
+
+				break
+			}
+		}
+	}
 }


### PR DESCRIPTION
The 1.5 spec says that undefined and ttl=null should mean the BSO never expires.

With this commit, when ttl:null is encounted it will be changed into 100
years (in seconds). The default BSO TTL is no 100 years as well.

However there now there is a subtle difference between undefined
TTL and ttl=null between insert/update behaviour:

TTL is undefined (not in the JSON)

    PUT .../storage/col/bsoId
     - insert: TTL is set to 100 years
     - update: TTL is *not* updated

TTL=null

    PUT .../storage/col/bsoId
     - insert: TTL is set to 100 years
     - update: TTL is set to 100 years

Refs: 
 - https://github.com/mozilla-services/server-syncstorage/pull/56 - add a functional test to prevent regressions
 - https://bugzilla.mozilla.org/show_bug.cgi?id=1332552