### PR TITLE
Fix syncPoolHandler not passing limit config to syncUserHandler

### DIFF
--- a/web/syncPoolHandler.go
+++ b/web/syncPoolHandler.go
@@ -56,16 +56,18 @@ func NewDefaultSyncPoolConfig(basepath string) *SyncPoolConfig {
 }
 
 func NewSyncPoolHandler(config *SyncPoolConfig, userHandlerConfig *SyncUserHandlerConfig) *SyncPoolHandler {
+
+	if userHandlerConfig == nil {
+		userHandlerConfig = NewDefaultSyncUserHandlerConfig()
+	}
+
 	pools := make([]*handlerPool, config.NumPools, config.NumPools)
 	for i := 0; i < config.NumPools; i++ {
 		pools[i] = newHandlerPool(
 			config.Basepath,
 			config.MaxPoolSize,
-			config.DBConfig)
-	}
-
-	if userHandlerConfig == nil {
-		userHandlerConfig = NewDefaultSyncUserHandlerConfig()
+			config.DBConfig,
+			userHandlerConfig)
 	}
 
 	server := &SyncPoolHandler{

--- a/web/syncPoolHandler_elements.go
+++ b/web/syncPoolHandler_elements.go
@@ -46,11 +46,12 @@ type handlerPool struct {
 	// the max size of the pool
 	maxPoolSize int
 
-	// the DB Configuration
-	dbConfig *syncstorage.Config
+	// Configurations
+	dbConfig          *syncstorage.Config
+	userHandlerConfig *SyncUserHandlerConfig
 }
 
-func newHandlerPool(basepath string, maxPoolSize int, dbConfig *syncstorage.Config) *handlerPool {
+func newHandlerPool(basepath string, maxPoolSize int, dbConfig *syncstorage.Config, userHandlerConfig *SyncUserHandlerConfig) *handlerPool {
 
 	var path []string
 
@@ -73,12 +74,13 @@ func newHandlerPool(basepath string, maxPoolSize int, dbConfig *syncstorage.Conf
 	}
 
 	pool := &handlerPool{
-		base:        path,
-		elements:    make(map[string]*poolElement),
-		lru:         list.New(),
-		lrumap:      make(map[string]*list.Element),
-		maxPoolSize: maxPoolSize,
-		dbConfig:    dbConfig,
+		base:              path,
+		elements:          make(map[string]*poolElement),
+		lru:               list.New(),
+		lrumap:            make(map[string]*list.Element),
+		maxPoolSize:       maxPoolSize,
+		dbConfig:          dbConfig,
+		userHandlerConfig: userHandlerConfig,
 	}
 
 	return pool
@@ -155,7 +157,7 @@ func (p *handlerPool) getElement(uid string) (*poolElement, bool, error) {
 
 		element = &poolElement{
 			uid:     uid,
-			handler: NewSyncUserHandler(uid, db, nil),
+			handler: NewSyncUserHandler(uid, db, p.userHandlerConfig),
 		}
 
 		elementCreated = true

--- a/web/syncPoolHandler_test.go
+++ b/web/syncPoolHandler_test.go
@@ -118,3 +118,32 @@ func TestSyncPoolCleanupHandlers(t *testing.T) {
 	pool.cleanupHandlers(2)
 	assert.Equal(t, 1, pool.lru.Len())
 }
+
+func TestSyncPoolPassesConfigToUserHandler(t *testing.T) {
+	assert := assert.New(t)
+	config := &SyncUserHandlerConfig{
+		MaxBSOGetLimit:        1,
+		MaxRequestBytes:       2,
+		MaxPOSTRecords:        3,
+		MaxPOSTBytes:          4,
+		MaxTotalRecords:       5,
+		MaxTotalBytes:         6,
+		MaxBatchTTL:           7,
+		MaxRecordPayloadBytes: 8,
+	}
+
+	handler := NewSyncPoolHandler(testSyncPoolConfig(), config)
+	el, _, err := handler.pools[0].getElement("1")
+	if !assert.NoError(err) {
+		return
+	}
+
+	assert.Equal(el.handler.config.MaxBSOGetLimit, 1)
+	assert.Equal(el.handler.config.MaxRequestBytes, 2)
+	assert.Equal(el.handler.config.MaxPOSTRecords, 3)
+	assert.Equal(el.handler.config.MaxPOSTBytes, 4)
+	assert.Equal(el.handler.config.MaxTotalRecords, 5)
+	assert.Equal(el.handler.config.MaxTotalBytes, 6)
+	assert.Equal(el.handler.config.MaxBatchTTL, 7)
+	assert.Equal(el.handler.config.MaxRecordPayloadBytes, 8)
+}

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -41,8 +41,8 @@ func NewDefaultSyncUserHandlerConfig() *SyncUserHandlerConfig {
 		MaxRequestBytes:       2 * 1024 * 1024,
 		MaxPOSTRecords:        100,
 		MaxPOSTBytes:          2 * 1024 * 1024,
-		MaxTotalRecords:       1000,
-		MaxTotalBytes:         20 * 1024 * 1024,
+		MaxTotalRecords:       10000,
+		MaxTotalBytes:         100 * 1024 * 1024,
 		MaxRecordPayloadBytes: 1024 * 256,
 
 		// batches older than this are likely to be purged


### PR DESCRIPTION
Stupid bug where syncPoolHandler did not pass the limit config to syncUserHandler. 

@grigoryk review please? 