### PR TITLE
Fix broken hawk hash generation

### DIFF
--- a/web/hawkHandler.go
+++ b/web/hawkHandler.go
@@ -180,7 +180,7 @@ func (h *HawkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		r.Body = ioutil.NopCloser(bytes.NewReader(content))
 		pHash := auth.PayloadHash(mediaType)
-		pHash.Sum(content)
+		pHash.Write(content)
 		if !auth.ValidHash(pHash) {
 			w.Header().Set("WWW-Authenticate", "Hawk")
 			sendRequestProblem(w, r, http.StatusForbidden,

--- a/web/hawkHandler_test.go
+++ b/web/hawkHandler_test.go
@@ -65,7 +65,7 @@ func hawkrequestbody(
 	if len(content) > 0 {
 		mediaType, _, _ := mime.ParseMediaType(contentType)
 		h := auth.PayloadHash(mediaType)
-		h.Sum(content)
+		h.Write(content)
 		auth.SetHash(h)
 		req.Header.Set("Content-Type", contentType)
 	}
@@ -157,10 +157,16 @@ func TestHawkAuthPOST(t *testing.T) {
 
 	tok := testtoken(hawkH.secrets[0], uid)
 
-	payload := "JUST A BUNCH OF DATA"
+	payload := "Thank you for flying Hawk"
 	body := bytes.NewBufferString(payload)
 
 	req, _ := hawkrequestbody("POST", syncurl(uid, "storage/collections/boom"), tok, "text/plain;charset=utf-8", body)
+
+	assert.Contains(req.Header.Get("Authorization"),
+		`hash="Yi9LfIIFRtBEPt74PVmbTF/xVAwPn7ub15ePICfgnuY="`,
+		"payload hash value invalid",
+	)
+
 	resp := sendrequest(req, hawkH)
 	assert.Equal(http.StatusOK, resp.Code)
 


### PR DESCRIPTION
PR #163 only fixed part of the problem. The code for generating the hash was wrong too. This fixes it and adds a check for proper payload hash validation. 