### PR TITLE
Fix usage of sync.RWMutex

### DIFF
--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -220,8 +220,8 @@ func NewDB(path string, conf *Config) (*DB, error) {
 
 // LastModified gets the database modified time
 func (d *DB) LastModified() (modified int, err error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	var m sql.NullInt64
 
@@ -238,8 +238,8 @@ func (d *DB) LastModified() (modified int, err error) {
 }
 
 func (d *DB) GetCollectionId(name string) (id int, err error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	// return common collection id without touching the DB
 	// ew? yes, but it'll compile nice and fast
@@ -283,8 +283,8 @@ func (d *DB) GetCollectionId(name string) (id int, err error) {
 }
 
 func (d *DB) GetCollectionModified(cId int) (modified int, err error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 	err = d.db.QueryRow("SELECT modified FROM Collections where Id=?", cId).Scan(&modified)
 	if err == sql.ErrNoRows {
 		return 0, nil
@@ -371,8 +371,8 @@ func (d *DB) TouchCollection(cId, modified int) (err error) {
 
 // InfoCollections create a map of collection names to last modified times
 func (d *DB) InfoCollections() (map[string]int, error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	rows, err := d.db.Query("SELECT Name,Modified FROM Collections WHERE Modified != 0")
 	if err != nil {
@@ -395,8 +395,8 @@ func (d *DB) InfoCollections() (map[string]int, error) {
 }
 
 func (d *DB) InfoQuota() (used, quota int, err error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	var u sql.NullInt64
 
@@ -421,8 +421,8 @@ func (d *DB) InfoQuota() (used, quota int, err error) {
 }
 
 func (d *DB) InfoCollectionUsage() (map[string]int, error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	query := `SELECT c.Name,sum(b.PayloadSize) used
 			  FROM BSO b, Collections C
@@ -449,8 +449,8 @@ func (d *DB) InfoCollectionUsage() (map[string]int, error) {
 }
 
 func (d *DB) InfoCollectionCounts() (map[string]int, error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	query := `SELECT c.Name, count(b.Id) count
 			  FROM BSO b, Collections C
@@ -573,8 +573,8 @@ func (d *DB) GetBSOs(
 	limit int,
 	offset int) (r *GetResults, err error) {
 
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	r, err = d.getBSOs(d.db, cId, ids, older, newer, sort, limit, offset)
 
@@ -582,8 +582,8 @@ func (d *DB) GetBSOs(
 }
 
 func (d *DB) GetBSOModified(cId int, bId string) (modified int, err error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 	err = d.db.QueryRow(`SELECT modified
 						 FROM BSO
 						 WHERE CollectionId=? and Id=? and TTL > ?`, cId, bId, Now()).Scan(&modified)
@@ -669,8 +669,8 @@ func (d *DB) PurgeExpired() (removed int, err error) {
 }
 
 func (d *DB) Usage() (stats *DBPageStats, err error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	stats = &DBPageStats{}
 
@@ -719,8 +719,8 @@ func (d *DB) SetKey(key, value string) error {
 
 // GetKey returns a previous key in the database
 func (d *DB) GetKey(key string) (string, error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 	return getKey(d.db, key)
 }
 

--- a/syncstorage/db_batch.go
+++ b/syncstorage/db_batch.go
@@ -81,8 +81,8 @@ func (d *DB) BatchAppend(id, cId int, data string) (err error) {
 
 // BatchExists checks if a batch exists without loading all the data from disk
 func (d *DB) BatchExists(id, cId int) (bool, error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	var foundId int
 	err := d.db.QueryRow("SELECT Id FROM Batches WHERE Id=? AND CollectionId=?", id, cId).Scan(&foundId)
@@ -98,8 +98,8 @@ func (d *DB) BatchExists(id, cId int) (bool, error) {
 }
 
 func (d *DB) BatchLoad(id, cId int) (*BatchRecord, error) {
-	d.Lock()
-	defer d.Unlock()
+	d.RLock()
+	defer d.RUnlock()
 
 	r := &BatchRecord{Id: id}
 


### PR DESCRIPTION
Now we can use all power of sync.RWMutex for read operations.