### PR TITLE
Fix #166 by removing GET BSO limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,12 @@ The server has a few knobs that can be tweaked.
 | `LOG_ONLY_HTTP_ERRORS` | Can be `true` or `false`. Logs only when `errno != 0` to reduce noise. Default `false`. |
 | `HOSTNAME` | Set a hostname value for mozlog output |
 | `LIMIT_MAX_REQUESTS_BYTES` | The maximum size in bytes of the overall HTTP request body that will be accepted by the server. |
-| `LIMIT_MAX_BSO_GET_LIMIT` |  Max BSOs that can be returned per GET request. Default: 2500. |
 | `LIMIT_MAX_POST_BYTES` |  Maximum size of a POST request. Default: 2097152 (2MB). |
 | `LIMIT_MAX_POST_RECORDS` |  Maximum number of BSOs per POST request. Default 100. |
 | `LIMIT_MAX_TOTAL_BYTES` |  Maximum total size of a POST batch job. Default: 26,214,400 (20MB). |
 | `LIMIT_MAX_TOTAL_RECORDS` | Maximum total BSOs in a POST batch job. Default 1000. |
 | `LIMIT_MAX_BATCH_TTL` | Maximum TTL for a batch to remain uncommitted in seconds. Default 7200 (2 hours). |
-| `INFO_CACHE_SIZE` | Cache size in MB for `<uid>/info/collections` and `<uid>/info/configuration`. Default 0 (disabled) | 
+| `INFO_CACHE_SIZE` | Cache size in MB for `<uid>/info/collections` and `<uid>/info/configuration`. Default 0 (disabled) |
 | `HAWK_TIMESTAMP_MAX_SKEW` | Sets number of seconds hawk timestamps can differ from the server. Default 60. |
 
 ## Advanced Configuration
@@ -76,7 +75,7 @@ The `POOL_PURGE_MIN_HOURS` and `POOL_PURGE_MAX_HOURS` define a time range to tri
 
 The `POOL_VACUUM_KB` sets the threshold before a vacuum is run. Purging of batches and BSOs free up database pages but not disk space. A vacuum will rewrite the database, defragment it and free up disk space. Depending on the number of records it can take seconds to vacuum a database.
 
-### Sqlite3 Tweaks 
+### Sqlite3 Tweaks
 
 | Env. Var | Info |
 |---|---|

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,6 @@ type LogConfig struct {
 // configures limits for web/SyncUserHandler
 type UserHandlerConfig struct {
 	MaxRequestBytes       int `envconfig:"default=2097152"`
-	MaxBSOGetLimit        int `envconfig:"default=1000"`
 	MaxPOSTRecords        int `envconfig:"default=100"`
 	MaxPOSTBytes          int `envconfig:"default=2097152"`
 	MaxTotalRecords       int `envconfig:"default=1000"`
@@ -138,9 +137,6 @@ func init() {
 		Config.Pool.Num = runtime.NumCPU()
 	}
 
-	if Config.Limit.MaxBSOGetLimit < 1 {
-		log.Fatal("LIMIT_MAX_BSO_GET_LIMIT must be >= 1")
-	}
 	if Config.Limit.MaxPOSTRecords < 1 {
 		log.Fatal("LIMIT_MAX_POST_RECORDS must be >= 1")
 	}

--- a/server.go
+++ b/server.go
@@ -38,7 +38,6 @@ func main() {
 
 	syncLimitConfig := web.NewDefaultSyncUserHandlerConfig()
 	syncLimitConfig.MaxRequestBytes = config.Limit.MaxRequestBytes
-	syncLimitConfig.MaxBSOGetLimit = config.Limit.MaxBSOGetLimit
 	syncLimitConfig.MaxPOSTRecords = config.Limit.MaxPOSTRecords
 	syncLimitConfig.MaxPOSTBytes = config.Limit.MaxPOSTBytes
 	syncLimitConfig.MaxTotalBytes = config.Limit.MaxTotalBytes
@@ -121,7 +120,6 @@ func main() {
 		"POOL_VACUUM_KB":                 config.Pool.VacuumKB,
 		"POOL_PURGE_MIN_HOURS":           config.Pool.PurgeMinHours,
 		"POOL_PURGE_MAX_HOURS":           config.Pool.PurgeMaxHours,
-		"LIMIT_MAX_BSO_GET_LIMIT":        syncLimitConfig.MaxBSOGetLimit,
 		"LIMIT_MAX_POST_RECORDS":         syncLimitConfig.MaxPOSTRecords,
 		"LIMIT_MAX_POST_BYTES":           syncLimitConfig.MaxPOSTBytes,
 		"LIMIT_MAX_TOTAL_RECORDS":        syncLimitConfig.MaxTotalRecords,

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -887,15 +887,12 @@ func (d *DB) getBSOs(
 		orderBy = "ORDER BY Modified ASC "
 	}
 
-	var limitStmt string
-	if limit > 0 {
-		limitStmt = "LIMIT ?"
-		values = append(values, limit)
+	limitStmt := "LIMIT ?"
+	values = append(values, limit)
 
-		if offset != 0 {
-			limitStmt += " OFFSET ?"
-			values = append(values, offset)
-		}
+	if offset != 0 {
+		limitStmt += " OFFSET ?"
+		values = append(values, offset)
 	}
 
 	countQuery := "SELECT COUNT(1) NumRows FROM BSO " + where + " " + orderBy

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -887,12 +887,15 @@ func (d *DB) getBSOs(
 		orderBy = "ORDER BY Modified ASC "
 	}
 
-	limitStmt := "LIMIT ?"
-	values = append(values, limit)
+	var limitStmt string
+	if limit > 0 {
+		limitStmt = "LIMIT ?"
+		values = append(values, limit)
 
-	if offset != 0 {
-		limitStmt += " OFFSET ?"
-		values = append(values, offset)
+		if offset != 0 {
+			limitStmt += " OFFSET ?"
+			values = append(values, offset)
+		}
 	}
 
 	countQuery := "SELECT COUNT(1) NumRows FROM BSO " + where + " " + orderBy

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -930,7 +930,6 @@ func (d *DB) getBSOs(
 		countQuery := "SELECT COUNT(1) NumRows FROM BSO " + where + " " + orderBy
 		if err := tx.QueryRow(countQuery, values...).Scan(&totalRows); err != nil {
 			return nil, err
-
 		}
 
 		if totalRows > limit+offset {

--- a/syncstorage/db.go
+++ b/syncstorage/db.go
@@ -86,14 +86,13 @@ func (p *PostResults) AddFailure(bId string, reasons ...string) {
 // GetResults holds search results for BSOs, this is what getBSOs() returns
 type GetResults struct {
 	BSOs   []*BSO
-	Total  int
 	More   bool
 	Offset int
 }
 
 func (g *GetResults) String() string {
 	s := fmt.Sprintf("Total: %d, More: %v, Offset: %d\nBSOs:\n",
-		g.Total, g.More, g.Offset)
+		len(g.BSOs), g.More, g.Offset)
 
 	for _, b := range g.BSOs {
 		s += fmt.Sprintf("  Id:%s, Modified:%d, SortIndex:%d, TTL:%d, %s\n",
@@ -895,13 +894,6 @@ func (d *DB) getBSOs(
 		values = append(values, offset)
 	}
 
-	countQuery := "SELECT COUNT(1) NumRows FROM BSO " + where + " " + orderBy
-	var totalRows int
-
-	if err := tx.QueryRow(countQuery, values...).Scan(&totalRows); err != nil {
-		return nil, err
-	}
-
 	resultQuery := fmt.Sprintf("%s %s %s %s", query, where, orderBy, limitStmt)
 	rows, err := tx.Query(resultQuery, values...)
 
@@ -928,15 +920,29 @@ func (d *DB) getBSOs(
 		}
 	}
 
-	nextOffset := 0
-	more := (totalRows > limit+offset)
-	if more {
-		nextOffset = offset + limit
+	var more bool
+	var nextOffset int
+
+	// if a limit was applied, determine if there are records beyond
+	// the upper bound and return the pertinent information
+	if limit > 0 {
+		var totalRows int
+		countQuery := "SELECT COUNT(1) NumRows FROM BSO " + where + " " + orderBy
+		if err := tx.QueryRow(countQuery, values...).Scan(&totalRows); err != nil {
+			return nil, err
+
+		}
+
+		if totalRows > limit+offset {
+			more = true
+			nextOffset = offset + limit
+		}
+	} else {
+		more = false
 	}
 
 	results := &GetResults{
 		BSOs:   bsos,
-		Total:  totalRows,
 		More:   more,
 		Offset: nextOffset,
 	}

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -324,12 +324,20 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
+	// make sure a limit of 0 returns all the records
+	allBSOs, err := db.getBSOs(tx, cId, nil, MaxTimestamp, 0, SORT_INDEX, 0, 0)
+	if !assert.NoError(err) {
+		return
+	}
+
+	assert.Len(allBSOs.BSOs, totalRecords)
+
 	newer := 0
 	limit := 5
 	offset := 0
 
 	// make sure invalid values don't work for limit and offset
-	_, err := db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, -1, offset)
+	_, err = db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, -1, offset)
 	assert.Equal(ErrInvalidLimit, err)
 	_, err = db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, limit, -1)
 	assert.Equal(ErrInvalidOffset, err)

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -325,7 +325,7 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 	}
 
 	// make sure a limit of 0 returns all the records
-	allBSOs, err := db.getBSOs(tx, cId, nil, MaxTimestamp, 0, SORT_INDEX, 0, 0)
+	allBSOs, err := db.getBSOs(tx, cId, nil, MaxTimestamp, 0, SORT_INDEX, -1, 0)
 	if !assert.NoError(err) {
 		return
 	}
@@ -337,9 +337,9 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 	offset := 0
 
 	// make sure invalid values don't work for limit and offset
-	_, err = db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, -1, offset)
+	_, err = db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, -2, offset)
 	assert.Equal(ErrInvalidLimit, err)
-	_, err = db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, limit, -1)
+	_, err = db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_INDEX, limit, -2)
 	assert.Equal(ErrInvalidOffset, err)
 
 	results, err := db.getBSOs(tx, cId, nil, MaxTimestamp, newer, SORT_NEWEST, limit, offset)

--- a/syncstorage/db_test.go
+++ b/syncstorage/db_test.go
@@ -347,7 +347,6 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 
 	if assert.NotNil(results) {
 		assert.Equal(5, len(results.BSOs), "Expected 5 results")
-		assert.Equal(totalRecords, results.Total, "Expected %d bsos to be found", totalRecords)
 		assert.True(results.More)
 		assert.Equal(5, results.Offset, "Expected next offset to be 5")
 
@@ -360,7 +359,6 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 	assert.NoError(err)
 	if assert.NotNil(results2) {
 		assert.Equal(5, len(results2.BSOs), "Expected 5 results")
-		assert.Equal(totalRecords, results.Total, "Expected %d bsos to be found", totalRecords)
 		assert.True(results2.More)
 		assert.Equal(10, results2.Offset, "Expected next offset to be 10")
 
@@ -373,7 +371,6 @@ func TestPrivateGetBSOsLimitOffset(t *testing.T) {
 	assert.NoError(err)
 	if assert.NotNil(results3) {
 		assert.Equal(2, len(results3.BSOs), "Expected 2 results")
-		assert.Equal(totalRecords, results.Total, "Expected %d bsos to be found", totalRecords)
 		assert.False(results3.More)
 
 		// make sure we get the right BSOs
@@ -408,7 +405,6 @@ func TestPrivateGetBSOsNewer(t *testing.T) {
 	results, err := db.getBSOs(tx, cId, nil, MaxTimestamp, modified-3, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
-		assert.Equal(3, results.Total)
 		assert.Equal(3, len(results.BSOs))
 		assert.Equal("b0", results.BSOs[0].Id)
 		assert.Equal("b1", results.BSOs[1].Id)
@@ -418,7 +414,6 @@ func TestPrivateGetBSOsNewer(t *testing.T) {
 	results, err = db.getBSOs(tx, cId, nil, MaxTimestamp, modified-2, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
-		assert.Equal(2, results.Total)
 		assert.Equal("b0", results.BSOs[0].Id)
 		assert.Equal("b1", results.BSOs[1].Id)
 	}
@@ -426,14 +421,12 @@ func TestPrivateGetBSOsNewer(t *testing.T) {
 	results, err = db.getBSOs(tx, cId, nil, MaxTimestamp, modified-1, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
-		assert.Equal(1, results.Total)
 		assert.Equal("b0", results.BSOs[0].Id)
 	}
 
 	results, err = db.getBSOs(tx, cId, nil, MaxTimestamp, modified, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
-		assert.Equal(0, results.Total)
 	}
 
 }
@@ -908,7 +901,6 @@ func TestGetBSOs(t *testing.T) {
 	results, err := db.GetBSOs(cId, []string{"b0", "b2", "b4"}, MaxTimestamp, 0, SORT_NEWEST, 10, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
-		assert.Equal(3, results.Total)
 		assert.Equal("b0", results.BSOs[0].Id) // created last
 		assert.Equal("b2", results.BSOs[1].Id)
 		assert.Equal("b4", results.BSOs[2].Id) // created first
@@ -917,7 +909,6 @@ func TestGetBSOs(t *testing.T) {
 	results, err = db.GetBSOs(cId, nil, MaxTimestamp, 0, SORT_INDEX, 2, 0)
 	assert.NoError(err)
 	if assert.NotNil(results) {
-		assert.Equal(5, results.Total)
 		assert.Equal(2, len(results.BSOs))
 		assert.Equal(2, results.Offset)
 		assert.True(results.More)

--- a/syncstorage/utils.go
+++ b/syncstorage/utils.go
@@ -74,8 +74,11 @@ func TTLOk(ttl int) bool {
 	return (ttl >= 0)
 }
 
+// LimitOk checks limit is within the correct range.
+// Acceptable values are -1 to max int. A limit of 0 would
+// return 0 records
 func LimitOk(limit int) bool {
-	return (limit >= 0)
+	return (limit >= -1)
 }
 
 func OffsetOk(offset int) bool {

--- a/syncstorage/utils.go
+++ b/syncstorage/utils.go
@@ -75,7 +75,7 @@ func TTLOk(ttl int) bool {
 }
 
 func LimitOk(limit int) bool {
-	return (limit > 0)
+	return (limit >= 0)
 }
 
 func OffsetOk(offset int) bool {

--- a/web/syncPoolHandler_test.go
+++ b/web/syncPoolHandler_test.go
@@ -122,14 +122,13 @@ func TestSyncPoolCleanupHandlers(t *testing.T) {
 func TestSyncPoolPassesConfigToUserHandler(t *testing.T) {
 	assert := assert.New(t)
 	config := &SyncUserHandlerConfig{
-		MaxBSOGetLimit:        1,
-		MaxRequestBytes:       2,
-		MaxPOSTRecords:        3,
-		MaxPOSTBytes:          4,
-		MaxTotalRecords:       5,
-		MaxTotalBytes:         6,
-		MaxBatchTTL:           7,
-		MaxRecordPayloadBytes: 8,
+		MaxRequestBytes:       1,
+		MaxPOSTRecords:        2,
+		MaxPOSTBytes:          3,
+		MaxTotalRecords:       4,
+		MaxTotalBytes:         5,
+		MaxBatchTTL:           6,
+		MaxRecordPayloadBytes: 7,
 	}
 
 	handler := NewSyncPoolHandler(testSyncPoolConfig(), config)
@@ -138,12 +137,11 @@ func TestSyncPoolPassesConfigToUserHandler(t *testing.T) {
 		return
 	}
 
-	assert.Equal(el.handler.config.MaxBSOGetLimit, 1)
-	assert.Equal(el.handler.config.MaxRequestBytes, 2)
-	assert.Equal(el.handler.config.MaxPOSTRecords, 3)
-	assert.Equal(el.handler.config.MaxPOSTBytes, 4)
-	assert.Equal(el.handler.config.MaxTotalRecords, 5)
-	assert.Equal(el.handler.config.MaxTotalBytes, 6)
-	assert.Equal(el.handler.config.MaxBatchTTL, 7)
-	assert.Equal(el.handler.config.MaxRecordPayloadBytes, 8)
+	assert.Equal(el.handler.config.MaxRequestBytes, 1)
+	assert.Equal(el.handler.config.MaxPOSTRecords, 2)
+	assert.Equal(el.handler.config.MaxPOSTBytes, 3)
+	assert.Equal(el.handler.config.MaxTotalRecords, 4)
+	assert.Equal(el.handler.config.MaxTotalBytes, 5)
+	assert.Equal(el.handler.config.MaxBatchTTL, 6)
+	assert.Equal(el.handler.config.MaxRecordPayloadBytes, 7)
 }

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -21,9 +21,6 @@ import (
 )
 
 type SyncUserHandlerConfig struct {
-	// Over rides
-	MaxBSOGetLimit int
-
 	// API Limits
 	MaxRequestBytes       int
 	MaxPOSTRecords        int
@@ -37,7 +34,6 @@ type SyncUserHandlerConfig struct {
 func NewDefaultSyncUserHandlerConfig() *SyncUserHandlerConfig {
 	return &SyncUserHandlerConfig{
 		// API Limits
-		MaxBSOGetLimit:        1000,
 		MaxRequestBytes:       2 * 1024 * 1024,
 		MaxPOSTRecords:        100,
 		MaxPOSTBytes:          2 * 1024 * 1024,
@@ -595,11 +591,8 @@ func (s *SyncUserHandler) hCollectionGET(w http.ResponseWriter, r *http.Request)
 			sendRequestProblem(w, r, http.StatusBadRequest, err)
 			return
 		}
-	}
-
-	// assign a default value for limit if nothing is supplied
-	if limit <= 0 || limit > s.config.MaxBSOGetLimit {
-		limit = s.config.MaxBSOGetLimit
+	} else {
+		limit = 0
 	}
 
 	if v := r.Form.Get("offset"); v != "" {

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -592,7 +592,9 @@ func (s *SyncUserHandler) hCollectionGET(w http.ResponseWriter, r *http.Request)
 			return
 		}
 	} else {
-		limit = 0
+		// in sqlite a negative value for LIMIT results in
+		// no upper bound, ref: http://sqlite.org/lang_select.html#limitoffset
+		limit = -1
 	}
 
 	if v := r.Form.Get("offset"); v != "" {

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -581,7 +581,7 @@ func (s *SyncUserHandler) hCollectionGET(w http.ResponseWriter, r *http.Request)
 
 	if v := r.Form.Get("limit"); v != "" {
 		limit, err = strconv.Atoi(v)
-		if err != nil || !syncstorage.LimitOk(limit) {
+		if err != nil || limit < 0 {
 			errMessage := "Invalid limit value"
 			if err != nil {
 				err = errors.Wrap(err, errMessage)
@@ -643,7 +643,7 @@ func (s *SyncUserHandler) hCollectionGET(w http.ResponseWriter, r *http.Request)
 	m := syncstorage.ModifiedToString(cmodified)
 	w.Header().Set("X-Last-Modified", m)
 
-	w.Header().Set("X-Weave-Records", strconv.Itoa(results.Total))
+	w.Header().Set("X-Weave-Records", strconv.Itoa(len(results.BSOs)))
 	if results.More {
 		w.Header().Set("X-Weave-Next-Offset", strconv.Itoa(results.Offset))
 	}


### PR DESCRIPTION
- There should be no limit on the amount of records a client
  can fetch in one request. This confirmed by this [1] comment
  on the python sync server
- Remove configuration option for limiting GET BSOs
- Refactor code for checking validity of limit and offset
- Made default behaviour return all requested BSOs

[1] https://github.com/mozilla-services/server-syncstorage/blob/b8feef17147af8819d50c9fae459e3e5de149d42/syncstorage/views/__init__.py#L247-L250