### PR TITLE
Fix #72 Reserve addresses and creditcards default collections

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,12 +7,12 @@ machine:
     A: "$GWS/src/github.com/$CIRCLE_PROJECT_USERNAME"
     B: "$A/$CIRCLE_PROJECT_REPONAME"
 
-    # Use to install Custom golang
-    GODIST: "go1.7.linux-amd64.tar.gz"
-    GODIST_HASH: "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95"
+    # Use to install Custom golang from https://golang.org/dl/
+    GODIST: "go1.9.linux-amd64.tar.gz"
+    GODIST_HASH: "d70eadefce8e160638a9a6db97f7192d8463069ab33138893ad3bf31b0650a79"
 
-    # Python container to test against
-    PYSYNC_VERSION: "1.6.7"
+    # server-syncstorage container to test against
+    PYSYNC_VERSION: "1.6.9"
 
   services:
     - docker

--- a/syncstorage/schemas.go
+++ b/syncstorage/schemas.go
@@ -62,3 +62,14 @@ const SCHEMA_0 = `
 
 	INSERT INTO KeyValues (Key, Value) VALUES ("SCHEMA_VERSION", 0);
 	`
+
+// Issue #72
+const SCHEMA_1 = `
+	INSERT INTO Collections (Id, Name) VALUES
+		( 12, "addresses"),
+		( 13, "creditcards");
+
+    -- begin using user_version to track schema changes
+	-- skip user_version=1 as that *should have been* set by 'SCHEMA_0'
+	PRAGMA user_version=2;
+`


### PR DESCRIPTION
This change is the first time we needed to update the schema. As a
result I added in a basic schema upgrade pattern with tests to
ensure it applies things correctly.

Other tweaks:
- upgrade circle to build with go 1.9
- upgrade circle to use pysync 1.6.9 for functional tests
- remove unnecessary test cleanup code