### PR TITLE
Increase default maximum payload size to 2MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The server has a few knobs that can be tweaked.
 | `LIMIT_MAX_TOTAL_BYTES` |  Maximum total size of a POST batch job. Default: 26,214,400 (20MB). |
 | `LIMIT_MAX_TOTAL_RECORDS` | Maximum total BSOs in a POST batch job. Default 1000. |
 | `LIMIT_MAX_BATCH_TTL` | Maximum TTL for a batch to remain uncommitted in seconds. Default 7200 (2 hours). |
+| `LIMIT_MAX_RECORD_PAYLOAD_BYTES` | Maximum bytes for a BSO payload. Default 2MB. | 
 | `INFO_CACHE_SIZE` | Cache size in MB for `<uid>/info/collections` and `<uid>/info/configuration`. Default 0 (disabled) |
 | `HAWK_TIMESTAMP_MAX_SKEW` | Sets number of seconds hawk timestamps can differ from the server. Default 60. |
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,8 +32,8 @@ type UserHandlerConfig struct {
 	MaxPOSTBytes          int `envconfig:"default=2097152"`
 	MaxTotalRecords       int `envconfig:"default=1000"`
 	MaxTotalBytes         int `envconfig:"default=20971520"`
-	MaxBatchTTL           int `envconfig:"default=7200"`   // 2 hours
-	MaxRecordPayloadBytes int `envconfig:"default=262144"` // 256KB
+	MaxBatchTTL           int `envconfig:"default=7200"`    // 2 hours
+	MaxRecordPayloadBytes int `envconfig:"default=2097152"` // 2MB
 }
 
 type PoolConfig struct {

--- a/web/syncUserHandler.go
+++ b/web/syncUserHandler.go
@@ -39,7 +39,7 @@ func NewDefaultSyncUserHandlerConfig() *SyncUserHandlerConfig {
 		MaxPOSTBytes:          2 * 1024 * 1024,
 		MaxTotalRecords:       10000,
 		MaxTotalBytes:         100 * 1024 * 1024,
-		MaxRecordPayloadBytes: 1024 * 256,
+		MaxRecordPayloadBytes: 1024 * 1024 * 2,
 
 		// batches older than this are likely to be purged
 		MaxBatchTTL: 2 * 60 * 60 * 1000, // 2 hours in milliseconds


### PR DESCRIPTION
- Add documentation for the env variable
  (LIMIT_MAX_RECORD_PAYLOAD_BYTES)
- Increase defaults to 2MB

Also see https://github.com/mozilla-services/server-syncstorage/pull/70 for the pysync changes.